### PR TITLE
[Fix]: QR Code Scanner now Functions Once Again

### DIFF
--- a/apps/client/src/app/conferences/qr-scan/qr-scan.component.html
+++ b/apps/client/src/app/conferences/qr-scan/qr-scan.component.html
@@ -2,7 +2,7 @@
   <zxing-scanner
     *ngIf="startCamera$ | async"
     [enable]="enable$ | async"
-    [autostart]="false"
+    [autostart]="true"
     [device]="selectedDevice$ | async"
     [formats]="['QR_CODE']"
     (camerasFound)="devices.next($event)"


### PR DESCRIPTION
# Overview

Resolves #28 - When 'autostart' was set to false on the camera it was unsurprisingly not starting. Setting this to true fixes that issue. I'm curious how this worked before since it's been like that for a couple of years now.

**Note:** Attached 'after' image has the simulator camera. This issue affected desktop and other browsers as well and I was able to confirm the fix works in those scenarios as well and is able to scan QR codes.

# Screenshots for Mobile and Desktop views (if applicable)

## Before

<img src="https://user-images.githubusercontent.com/9042219/219081625-273067cf-bc6e-4e14-8298-88ea1c04561d.png" width="300">

## After

<img src="https://user-images.githubusercontent.com/4316134/219758749-c1631c56-59ac-4542-8cdd-f91cbacb50f4.png" width="300">

# Details

## General

- Set 'autostart' on 'zxing-scanner' component to 'true'.

## Automated Testing

N/A

### Manual Testing

1. Run `nx client:serve`
2. In browser, goto localhost:4200
3. Tap on 'Join Conference'
4. Tap 'Scan a QR Code'
5. You should see a camera feed if you have a camera