### PR TITLE
[Fix]: Implement Persistent New Connection Dismissal

### DIFF
--- a/apps/client/src/app/connect/connect.component.html
+++ b/apps/client/src/app/connect/connect.component.html
@@ -17,14 +17,16 @@
             <cm-connect-card [attendee]="candidate.attendee"></cm-connect-card>
           </div>
         </ng-container>
-        <cm-new-connection
-          *ngIf="newPairMatch$ | async as newPairMatch"
-          [matchAttendee]="newPairMatch.attendee"
-          [hidden]="isNewConnectionClosed"
-          (chat)="onNewConnectionChat(newPairMatch.id)"
-          (dismiss)="onNewConnectionClose()"
-        >
-        </cm-new-connection>
+        <ng-container *ngrxLet="(newPairMatch$ | async) as newPairMatch">
+          <cm-new-connection
+            *ngIf="newPairMatch && newPairMatch[0]"
+            [matchAttendee]="newPairMatch[0].attendee"
+            [hidden]="isNewConnectionClosed"
+            (chat)="onNewConnectionChat(newPairMatch[0], newPairMatch[1])"
+            (dismiss)="onNewConnectionClose(newPairMatch[0], newPairMatch[1])"
+          >
+          </cm-new-connection>
+        </ng-container>
       </div>
       <div class="cm-connect__actions">
         <div class="button-container">
@@ -37,7 +39,7 @@
               !(
                 (lastActionInHistory?.type === CandidateType.LIKE ||
                   lastActionInHistory?.type === CandidateType.DISLIKE) &&
-                (newPairMatch$ | async)?.attendee?.id !==
+                (newPairMatch$ | async)[0]?.attendee?.id !==
                   lastActionInHistory?.candidate?.attendee?.id
               )
             "
@@ -99,14 +101,16 @@
       "
       class="cm-connect__no-results"
     >
-      <cm-new-connection
-        *ngIf="newPairMatch$ | async as newPairMatch"
-        [matchAttendee]="newPairMatch.attendee"
-        [hidden]="isNewConnectionClosed"
-        (chat)="onNewConnectionChat(newPairMatch.id)"
-        (dismiss)="onNewConnectionClose()"
-      >
-      </cm-new-connection>
+      <ng-container *ngrxLet="(newPairMatch$ | async) as newPairMatch">
+        <cm-new-connection
+          *ngIf="newPairMatch && newPairMatch[0]"
+          [matchAttendee]="newPairMatch[0].attendee"
+          [hidden]="isNewConnectionClosed"
+          (chat)="onNewConnectionChat(newPairMatch[0], newPairMatch[1])"
+          (dismiss)="onNewConnectionClose(newPairMatch[0], newPairMatch[1])"
+        >
+        </cm-new-connection>
+      </ng-container>
       <img
         class="cm-connect__no-results__image"
         src="assets/connect-no-results.svg"
@@ -120,7 +124,7 @@
   </ng-container>
 </ng-container>
 
-<div *ngIf="action === 'confirmLike' && newMatch$ | async as newMatch">
+<div *ngIf="action === 'confirmLike' && (newMatch$ | async) as newMatch">
   <cm-you-are-chatters-card
     [match]="newMatch"
     (chat)="onNewConnectionChat(newMatch.id)"

--- a/apps/client/src/app/connect/connect.component.html
+++ b/apps/client/src/app/connect/connect.component.html
@@ -17,7 +17,7 @@
             <cm-connect-card [attendee]="candidate.attendee"></cm-connect-card>
           </div>
         </ng-container>
-        <ng-container *ngrxLet="(newPairMatch$ | async) as newPairMatch">
+        <ng-container *ngrxLet="newPairMatch$ | async as newPairMatch">
           <cm-new-connection
             *ngIf="newPairMatch && newPairMatch[0]"
             [matchAttendee]="newPairMatch[0].attendee"
@@ -31,6 +31,7 @@
       <div class="cm-connect__actions">
         <div class="button-container">
           <button
+            *ngrxLet="newPairMatch$ | async as newPairMatch"
             class="cm-connect__actions__back"
             cm-action-button
             [attr.aria-label]="t('button.undo')"
@@ -39,7 +40,7 @@
               !(
                 (lastActionInHistory?.type === CandidateType.LIKE ||
                   lastActionInHistory?.type === CandidateType.DISLIKE) &&
-                (newPairMatch$ | async)[0]?.attendee?.id !==
+                (newPairMatch && newPairMatch[0])?.attendee?.id !==
                   lastActionInHistory?.candidate?.attendee?.id
               )
             "
@@ -101,7 +102,7 @@
       "
       class="cm-connect__no-results"
     >
-      <ng-container *ngrxLet="(newPairMatch$ | async) as newPairMatch">
+      <ng-container *ngrxLet="newPairMatch$ | async as newPairMatch">
         <cm-new-connection
           *ngIf="newPairMatch && newPairMatch[0]"
           [matchAttendee]="newPairMatch[0].attendee"

--- a/apps/client/src/app/connect/connect.component.ts
+++ b/apps/client/src/app/connect/connect.component.ts
@@ -10,12 +10,14 @@ import {
   ConnectActions,
   ConnectSelectors,
 } from '@conf-match/client/conference/connect/data-access';
-import { MatchesSelectors } from '@conf-match/client/conference/matches/data-access';
-import { MatchesActions } from '@conf-match/client/conference/messages/data-access';
+import {
+  MatchesSelectors,
+  MatchesActions,
+} from '@conf-match/client/conference/matches/data-access';
+import { MatchesActions as MatchesMessagesActions } from '@conf-match/client/conference/messages/data-access';
 import { selectAttendee } from '@conf-match/core';
 import { ModalService, Storage } from '@conf-match/shared';
 import { Store } from '@ngrx/store';
-import { markMatchAsRead } from 'libs/client/conference/matches/data-access/src/lib/state/actions/matches.actions';
 import { combineLatest, Observable, Subscription } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
 import { OnboardingComponent } from './onboarding/onboarding.component';
@@ -98,7 +100,7 @@ export class ConnectComponent implements OnInit, OnDestroy {
   onNewConnectionClose(match: Match, attendee: Attendee) {
     this.isNewConnectionClosed = true;
     this.store.dispatch(
-      markMatchAsRead({
+      MatchesActions.markMatchAsRead({
         matchId: match.id,
         attendeeId: attendee.id,
         attendee1Id: match.attendee1Id,
@@ -108,9 +110,9 @@ export class ConnectComponent implements OnInit, OnDestroy {
   }
 
   onNewConnectionChat(match: Match, attendee: Attendee) {
-    this.store.dispatch(MatchesActions.startChatConversation({ matchId: match.id }));
+    this.store.dispatch(MatchesMessagesActions.startChatConversation({ matchId: match.id }));
     this.store.dispatch(
-      markMatchAsRead({
+      MatchesActions.markMatchAsRead({
         matchId: match.id,
         attendeeId: attendee.id,
         attendee1Id: match.attendee1Id,

--- a/apps/client/src/app/connect/connect.component.ts
+++ b/apps/client/src/app/connect/connect.component.ts
@@ -17,7 +17,7 @@ import { ModalService, Storage } from '@conf-match/shared';
 import { Store } from '@ngrx/store';
 import { markMatchAsRead } from 'libs/client/conference/matches/data-access/src/lib/state/actions/matches.actions';
 import { combineLatest, Observable, Subscription } from 'rxjs';
-import { filter, map, take, tap } from 'rxjs/operators';
+import { filter, map, take } from 'rxjs/operators';
 import { OnboardingComponent } from './onboarding/onboarding.component';
 
 // TODO: Decide where that key will be kept
@@ -54,7 +54,6 @@ export class ConnectComponent implements OnInit, OnDestroy {
     this.store.select(MatchesSelectors.selectNewPairMatch),
     this.store.select(selectAttendee),
   ]).pipe(
-    tap((x) => console.log(x)),
     filter(
       ([pairMatch, attendee]) =>
         !(

--- a/apps/client/src/app/connect/connect.module.ts
+++ b/apps/client/src/app/connect/connect.module.ts
@@ -9,8 +9,8 @@ import { OnboardingComponent } from './onboarding/onboarding.component';
 import { SharedUiIconsModule } from '@conf-match/shared/ui-icons';
 import { SharedUiButtonsModule } from '@conf-match/shared/ui-buttons';
 import { RouteTag } from '@conf-match/shared/route-tags';
-
 import { ClientConferenceConnectDataAccessModule } from '@conf-match/client/conference/connect/data-access';
+import { LetModule } from '@ngrx/component';
 
 const routes: Routes = [
   {
@@ -27,6 +27,7 @@ const routes: Routes = [
   imports: [
     CommonModule,
     RouterModule.forChild(routes),
+    LetModule,
     ClientConferenceConnectDataAccessModule,
     CmSharedModule,
     AppSharedModule,

--- a/libs/api/src/graphql/mutations.graphql
+++ b/libs/api/src/graphql/mutations.graphql
@@ -37,6 +37,8 @@ mutation CreateAttendee($input: CreateAttendeeInput!) {
       attendee2Id
       eventId
       createdAt
+      viewedByAttendee1
+      viewedByAttendee2
       updatedAt
     }
     attendeeChats {
@@ -108,6 +110,8 @@ mutation UpdateAttendee($input: UpdateAttendeeInput!) {
       attendee2Id
       eventId
       createdAt
+      viewedByAttendee1
+      viewedByAttendee2
       updatedAt
     }
     attendeeChats {
@@ -1520,6 +1524,8 @@ mutation UpdateChatThread(
       attendee2Id
       eventId
       createdAt
+      viewedByAttendee1
+      viewedByAttendee2
       updatedAt
     }
     createdAt
@@ -1565,6 +1571,87 @@ mutation CreateMessage(
       createdAt
       updatedAt
     }
+    updatedAt
+  }
+}
+mutation UpdateMatch(
+  $input: UpdateMatchInput!
+  $condition: ModelMatchConditionInput
+) {
+  updateMatch(input: $input, condition: $condition) {
+    id
+    owners
+    attendee1Id
+    attendee2Id
+    eventId
+    event {
+      id
+      organizationId
+      owners
+      readers
+      name
+      status
+      size
+      logoUrl
+      qrImageUrl
+      description
+      registrationCode
+      letsChatWithUrl
+      website
+      facebook
+      twitter
+      maxInterests
+      maxIdentifiers
+      totalAmountDue
+      paymentStatus
+      createdAt
+      updatedAt
+    }
+    createdAt
+    attendee1 {
+      id
+      owner
+      userId
+      fullName
+      avatarUrl
+      title
+      company
+      pronouns
+      bio
+      newsletterSubscribed
+      linkedin
+      twitter
+      facebook
+      eventId
+      createdAt
+      updatedAt
+    }
+    attendee2 {
+      id
+      owner
+      userId
+      fullName
+      avatarUrl
+      title
+      company
+      pronouns
+      bio
+      newsletterSubscribed
+      linkedin
+      twitter
+      facebook
+      eventId
+      createdAt
+      updatedAt
+    }
+    interests {
+      nextToken
+    }
+    desiredIdentifiers {
+      nextToken
+    }
+    viewedByAttendee1
+    viewedByAttendee2
     updatedAt
   }
 }
@@ -1644,6 +1731,8 @@ mutation DeleteMatch(
     desiredIdentifiers {
       nextToken
     }
+    viewedByAttendee1
+    viewedByAttendee2
     updatedAt
   }
 }
@@ -1854,6 +1943,8 @@ mutation CreateMatchInterest(
       attendee2Id
       eventId
       createdAt
+      viewedByAttendee1
+      viewedByAttendee2
       updatedAt
     }
     interest {
@@ -1885,6 +1976,8 @@ mutation UpdateMatchInterest(
       attendee2Id
       eventId
       createdAt
+      viewedByAttendee1
+      viewedByAttendee2
       updatedAt
     }
     interest {
@@ -1916,6 +2009,8 @@ mutation DeleteMatchInterest(
       attendee2Id
       eventId
       createdAt
+      viewedByAttendee1
+      viewedByAttendee2
       updatedAt
     }
     interest {
@@ -1947,6 +2042,8 @@ mutation CreateMatchDesiredIdentifier(
       attendee2Id
       eventId
       createdAt
+      viewedByAttendee1
+      viewedByAttendee2
       updatedAt
     }
     desiredIdentifier {
@@ -1977,6 +2074,8 @@ mutation UpdateMatchDesiredIdentifier(
       attendee2Id
       eventId
       createdAt
+      viewedByAttendee1
+      viewedByAttendee2
       updatedAt
     }
     desiredIdentifier {
@@ -2007,6 +2106,8 @@ mutation DeleteMatchDesiredIdentifier(
       attendee2Id
       eventId
       createdAt
+      viewedByAttendee1
+      viewedByAttendee2
       updatedAt
     }
     desiredIdentifier {

--- a/libs/api/src/graphql/queries.graphql
+++ b/libs/api/src/graphql/queries.graphql
@@ -316,6 +316,8 @@ query GetAttendee($id: ID!) {
       attendee2Id
       eventId
       createdAt
+      viewedByAttendee1
+      viewedByAttendee2
       updatedAt
     }
     attendeeChats {
@@ -504,6 +506,8 @@ query GetChatThread($id: ID!) {
       attendee2Id
       eventId
       createdAt
+      viewedByAttendee1
+      viewedByAttendee2
       updatedAt
     }
     createdAt
@@ -682,6 +686,8 @@ query GetMatch($id: ID!) {
     desiredIdentifiers {
       nextToken
     }
+    viewedByAttendee1
+    viewedByAttendee2
     updatedAt
   }
 }
@@ -698,6 +704,8 @@ query ListMatches(
       attendee2Id
       eventId
       createdAt
+      viewedByAttendee1
+      viewedByAttendee2
       updatedAt
     }
     nextToken

--- a/libs/api/src/lib/api.service.ts
+++ b/libs/api/src/lib/api.service.ts
@@ -147,6 +147,8 @@ export type Match = {
   attendee2?: Attendee | null;
   interests?: ModelMatchInterestConnection | null;
   desiredIdentifiers?: ModelMatchDesiredIdentifierConnection | null;
+  viewedByAttendee1?: boolean | null;
+  viewedByAttendee2?: boolean | null;
   updatedAt: string;
 };
 
@@ -1101,8 +1103,15 @@ export type ModelMessageConditionInput = {
   not?: ModelMessageConditionInput | null;
 };
 
-export type DeleteMatchInput = {
+export type UpdateMatchInput = {
   id: string;
+  owners?: Array<string> | null;
+  attendee1Id?: string | null;
+  attendee2Id?: string | null;
+  eventId?: string | null;
+  createdAt?: string | null;
+  viewedByAttendee1?: boolean | null;
+  viewedByAttendee2?: boolean | null;
 };
 
 export type ModelMatchConditionInput = {
@@ -1110,9 +1119,15 @@ export type ModelMatchConditionInput = {
   attendee2Id?: ModelIDInput | null;
   eventId?: ModelIDInput | null;
   createdAt?: ModelStringInput | null;
+  viewedByAttendee1?: ModelBooleanInput | null;
+  viewedByAttendee2?: ModelBooleanInput | null;
   and?: Array<ModelMatchConditionInput | null> | null;
   or?: Array<ModelMatchConditionInput | null> | null;
   not?: ModelMatchConditionInput | null;
+};
+
+export type DeleteMatchInput = {
+  id: string;
 };
 
 export type CreateCandidateInterestInput = {
@@ -1435,6 +1450,8 @@ export type ModelMatchFilterInput = {
   attendee2Id?: ModelIDInput | null;
   eventId?: ModelIDInput | null;
   createdAt?: ModelStringInput | null;
+  viewedByAttendee1?: ModelBooleanInput | null;
+  viewedByAttendee2?: ModelBooleanInput | null;
   and?: Array<ModelMatchFilterInput | null> | null;
   or?: Array<ModelMatchFilterInput | null> | null;
   not?: ModelMatchFilterInput | null;
@@ -1506,6 +1523,8 @@ export type CreateAttendeeMutation = {
     attendee2Id: string;
     eventId: string;
     createdAt: string;
+    viewedByAttendee1?: boolean | null;
+    viewedByAttendee2?: boolean | null;
     updatedAt: string;
   } | null> | null;
   attendeeChats?: Array<{
@@ -1583,6 +1602,8 @@ export type UpdateAttendeeMutation = {
     attendee2Id: string;
     eventId: string;
     createdAt: string;
+    viewedByAttendee1?: boolean | null;
+    viewedByAttendee2?: boolean | null;
     updatedAt: string;
   } | null> | null;
   attendeeChats?: Array<{
@@ -2962,6 +2983,8 @@ export type UpdateChatThreadMutation = {
     attendee2Id: string;
     eventId: string;
     createdAt: string;
+    viewedByAttendee1?: boolean | null;
+    viewedByAttendee2?: boolean | null;
     updatedAt: string;
   } | null;
   createdAt: string;
@@ -3006,6 +3029,89 @@ export type CreateMessageMutation = {
     createdAt: string;
     updatedAt: string;
   };
+  updatedAt: string;
+};
+
+export type UpdateMatchMutation = {
+  __typename: 'Match';
+  id: string;
+  owners: Array<string>;
+  attendee1Id: string;
+  attendee2Id: string;
+  eventId: string;
+  event?: {
+    __typename: 'Event';
+    id: string;
+    organizationId: string;
+    owners: Array<string>;
+    readers?: Array<string> | null;
+    name: string;
+    status: EventStatus;
+    size: EventSize;
+    logoUrl?: string | null;
+    qrImageUrl?: string | null;
+    description?: string | null;
+    registrationCode?: string | null;
+    letsChatWithUrl: string;
+    website?: string | null;
+    facebook?: string | null;
+    twitter?: string | null;
+    maxInterests?: number | null;
+    maxIdentifiers?: number | null;
+    totalAmountDue?: number | null;
+    paymentStatus?: EventPaymentStatus | null;
+    createdAt: string;
+    updatedAt: string;
+  } | null;
+  createdAt: string;
+  attendee1?: {
+    __typename: 'Attendee';
+    id: string;
+    owner?: string | null;
+    userId: string;
+    fullName: string;
+    avatarUrl?: string | null;
+    title?: string | null;
+    company?: string | null;
+    pronouns?: string | null;
+    bio?: string | null;
+    newsletterSubscribed?: boolean | null;
+    linkedin?: string | null;
+    twitter?: string | null;
+    facebook?: string | null;
+    eventId: string;
+    createdAt: string;
+    updatedAt: string;
+  } | null;
+  attendee2?: {
+    __typename: 'Attendee';
+    id: string;
+    owner?: string | null;
+    userId: string;
+    fullName: string;
+    avatarUrl?: string | null;
+    title?: string | null;
+    company?: string | null;
+    pronouns?: string | null;
+    bio?: string | null;
+    newsletterSubscribed?: boolean | null;
+    linkedin?: string | null;
+    twitter?: string | null;
+    facebook?: string | null;
+    eventId: string;
+    createdAt: string;
+    updatedAt: string;
+  } | null;
+  interests?: {
+    __typename: 'ModelMatchInterestConnection';
+    nextToken?: string | null;
+  } | null;
+  desiredIdentifiers?: {
+    __typename: 'ModelMatchDesiredIdentifierConnection';
+    nextToken?: string | null;
+  } | null;
+  viewedByAttendee1?: boolean | null;
+  viewedByAttendee2?: boolean | null;
   updatedAt: string;
 };
 
@@ -3087,6 +3193,8 @@ export type DeleteMatchMutation = {
     __typename: 'ModelMatchDesiredIdentifierConnection';
     nextToken?: string | null;
   } | null;
+  viewedByAttendee1?: boolean | null;
+  viewedByAttendee2?: boolean | null;
   updatedAt: string;
 };
 
@@ -3289,6 +3397,8 @@ export type CreateMatchInterestMutation = {
     attendee2Id: string;
     eventId: string;
     createdAt: string;
+    viewedByAttendee1?: boolean | null;
+    viewedByAttendee2?: boolean | null;
     updatedAt: string;
   };
   interest: {
@@ -3319,6 +3429,8 @@ export type UpdateMatchInterestMutation = {
     attendee2Id: string;
     eventId: string;
     createdAt: string;
+    viewedByAttendee1?: boolean | null;
+    viewedByAttendee2?: boolean | null;
     updatedAt: string;
   };
   interest: {
@@ -3349,6 +3461,8 @@ export type DeleteMatchInterestMutation = {
     attendee2Id: string;
     eventId: string;
     createdAt: string;
+    viewedByAttendee1?: boolean | null;
+    viewedByAttendee2?: boolean | null;
     updatedAt: string;
   };
   interest: {
@@ -3379,6 +3493,8 @@ export type CreateMatchDesiredIdentifierMutation = {
     attendee2Id: string;
     eventId: string;
     createdAt: string;
+    viewedByAttendee1?: boolean | null;
+    viewedByAttendee2?: boolean | null;
     updatedAt: string;
   };
   desiredIdentifier: {
@@ -3408,6 +3524,8 @@ export type UpdateMatchDesiredIdentifierMutation = {
     attendee2Id: string;
     eventId: string;
     createdAt: string;
+    viewedByAttendee1?: boolean | null;
+    viewedByAttendee2?: boolean | null;
     updatedAt: string;
   };
   desiredIdentifier: {
@@ -3437,6 +3555,8 @@ export type DeleteMatchDesiredIdentifierMutation = {
     attendee2Id: string;
     eventId: string;
     createdAt: string;
+    viewedByAttendee1?: boolean | null;
+    viewedByAttendee2?: boolean | null;
     updatedAt: string;
   };
   desiredIdentifier: {
@@ -3744,6 +3864,8 @@ export type GetAttendeeQuery = {
     attendee2Id: string;
     eventId: string;
     createdAt: string;
+    viewedByAttendee1?: boolean | null;
+    viewedByAttendee2?: boolean | null;
     updatedAt: string;
   } | null> | null;
   attendeeChats?: Array<{
@@ -3923,6 +4045,8 @@ export type GetChatThreadQuery = {
     attendee2Id: string;
     eventId: string;
     createdAt: string;
+    viewedByAttendee1?: boolean | null;
+    viewedByAttendee2?: boolean | null;
     updatedAt: string;
   } | null;
   createdAt: string;
@@ -4104,6 +4228,8 @@ export type GetMatchQuery = {
     __typename: 'ModelMatchDesiredIdentifierConnection';
     nextToken?: string | null;
   } | null;
+  viewedByAttendee1?: boolean | null;
+  viewedByAttendee2?: boolean | null;
   updatedAt: string;
 };
 
@@ -4117,6 +4243,8 @@ export type ListMatchesQuery = {
     attendee2Id: string;
     eventId: string;
     createdAt: string;
+    viewedByAttendee1?: boolean | null;
+    viewedByAttendee2?: boolean | null;
     updatedAt: string;
   } | null>;
   nextToken?: string | null;
@@ -4271,6 +4399,8 @@ export class APIService {
             attendee2Id
             eventId
             createdAt
+            viewedByAttendee1
+            viewedByAttendee2
             updatedAt
           }
           attendeeChats {
@@ -4358,6 +4488,8 @@ export class APIService {
             attendee2Id
             eventId
             createdAt
+            viewedByAttendee1
+            viewedByAttendee2
             updatedAt
           }
           attendeeChats {
@@ -6352,6 +6484,8 @@ export class APIService {
             attendee2Id
             eventId
             createdAt
+            viewedByAttendee1
+            viewedByAttendee2
             updatedAt
           }
           createdAt
@@ -6425,6 +6559,105 @@ export class APIService {
       graphqlOperation(statement, gqlAPIServiceArguments)
     )) as any;
     return <CreateMessageMutation>response.data.createMessage;
+  }
+  async UpdateMatch(
+    input: UpdateMatchInput,
+    condition?: ModelMatchConditionInput
+  ): Promise<UpdateMatchMutation> {
+    const statement = `mutation UpdateMatch($input: UpdateMatchInput!, $condition: ModelMatchConditionInput) {
+        updateMatch(input: $input, condition: $condition) {
+          __typename
+          id
+          owners
+          attendee1Id
+          attendee2Id
+          eventId
+          event {
+            __typename
+            id
+            organizationId
+            owners
+            readers
+            name
+            status
+            size
+            logoUrl
+            qrImageUrl
+            description
+            registrationCode
+            letsChatWithUrl
+            website
+            facebook
+            twitter
+            maxInterests
+            maxIdentifiers
+            totalAmountDue
+            paymentStatus
+            createdAt
+            updatedAt
+          }
+          createdAt
+          attendee1 {
+            __typename
+            id
+            owner
+            userId
+            fullName
+            avatarUrl
+            title
+            company
+            pronouns
+            bio
+            newsletterSubscribed
+            linkedin
+            twitter
+            facebook
+            eventId
+            createdAt
+            updatedAt
+          }
+          attendee2 {
+            __typename
+            id
+            owner
+            userId
+            fullName
+            avatarUrl
+            title
+            company
+            pronouns
+            bio
+            newsletterSubscribed
+            linkedin
+            twitter
+            facebook
+            eventId
+            createdAt
+            updatedAt
+          }
+          interests {
+            __typename
+            nextToken
+          }
+          desiredIdentifiers {
+            __typename
+            nextToken
+          }
+          viewedByAttendee1
+          viewedByAttendee2
+          updatedAt
+        }
+      }`;
+    const gqlAPIServiceArguments: any = {
+      input,
+    };
+    if (condition) {
+      gqlAPIServiceArguments.condition = condition;
+    }
+    const response = (await API.graphql(
+      graphqlOperation(statement, gqlAPIServiceArguments)
+    )) as any;
+    return <UpdateMatchMutation>response.data.updateMatch;
   }
   async DeleteMatch(
     input: DeleteMatchInput,
@@ -6509,6 +6742,8 @@ export class APIService {
             __typename
             nextToken
           }
+          viewedByAttendee1
+          viewedByAttendee2
           updatedAt
         }
       }`;
@@ -6823,6 +7058,8 @@ export class APIService {
             attendee2Id
             eventId
             createdAt
+            viewedByAttendee1
+            viewedByAttendee2
             updatedAt
           }
           interest {
@@ -6869,6 +7106,8 @@ export class APIService {
             attendee2Id
             eventId
             createdAt
+            viewedByAttendee1
+            viewedByAttendee2
             updatedAt
           }
           interest {
@@ -6915,6 +7154,8 @@ export class APIService {
             attendee2Id
             eventId
             createdAt
+            viewedByAttendee1
+            viewedByAttendee2
             updatedAt
           }
           interest {
@@ -6961,6 +7202,8 @@ export class APIService {
             attendee2Id
             eventId
             createdAt
+            viewedByAttendee1
+            viewedByAttendee2
             updatedAt
           }
           desiredIdentifier {
@@ -7006,6 +7249,8 @@ export class APIService {
             attendee2Id
             eventId
             createdAt
+            viewedByAttendee1
+            viewedByAttendee2
             updatedAt
           }
           desiredIdentifier {
@@ -7051,6 +7296,8 @@ export class APIService {
             attendee2Id
             eventId
             createdAt
+            viewedByAttendee1
+            viewedByAttendee2
             updatedAt
           }
           desiredIdentifier {
@@ -7604,6 +7851,8 @@ export class APIService {
             attendee2Id
             eventId
             createdAt
+            viewedByAttendee1
+            viewedByAttendee2
             updatedAt
           }
           attendeeChats {
@@ -7858,6 +8107,8 @@ export class APIService {
             attendee2Id
             eventId
             createdAt
+            viewedByAttendee1
+            viewedByAttendee2
             updatedAt
           }
           createdAt
@@ -8101,6 +8352,8 @@ export class APIService {
             __typename
             nextToken
           }
+          viewedByAttendee1
+          viewedByAttendee2
           updatedAt
         }
       }`;
@@ -8128,6 +8381,8 @@ export class APIService {
             attendee2Id
             eventId
             createdAt
+            viewedByAttendee1
+            viewedByAttendee2
             updatedAt
           }
           nextToken

--- a/libs/api/src/lib/fragment/match.fragment.ts
+++ b/libs/api/src/lib/fragment/match.fragment.ts
@@ -56,6 +56,8 @@ export const matchFragment = gql`
       }
     }
     createdAt
+    viewedByAttendee1
+    viewedByAttendee2
   }
 `;
 
@@ -122,6 +124,8 @@ export const matchDetailsFragment = gql`
       }
     }
     createdAt
+    viewedByAttendee1
+    viewedByAttendee2
   }
 `;
 
@@ -153,6 +157,8 @@ export interface MatchFragment {
   createdAt: string;
   interests?: { items: MatchInterestFragment[] };
   desiredIdentifiers?: { items: MatchDesiredIdentifierFragment[] };
+  viewedByAttendee1?: boolean;
+  viewedByAttendee2?: boolean;
 }
 
 export interface MatchAttendeeDetailsFragment {
@@ -177,4 +183,5 @@ export interface MatchDetailsFragment {
   createdAt: string;
   interests?: InterestModel[];
   desiredIdentifiers?: IdentifierModel[];
+  viewedBy?: string[];
 }

--- a/libs/api/src/lib/model/index.ts
+++ b/libs/api/src/lib/model/index.ts
@@ -117,6 +117,8 @@ export interface Match {
   createdAt: string;
   interests: MatchInterest[];
   desiredIdentifiers: MatchDesiredIdentifier[];
+  viewedByAttendee1?: boolean;
+  viewedByAttendee2?: boolean;
 }
 
 export interface MatchDetails {

--- a/libs/api/src/lib/mutations/index.ts
+++ b/libs/api/src/lib/mutations/index.ts
@@ -10,4 +10,5 @@ export * from './update-user';
 export * from './update-report';
 export * from './file-upload';
 export * from './update-chat-thread';
+export * from './update-match';
 export * from './delete-match';

--- a/libs/api/src/lib/mutations/update-match.ts
+++ b/libs/api/src/lib/mutations/update-match.ts
@@ -1,0 +1,16 @@
+import gql from 'graphql-tag';
+import { Injectable } from '@angular/core';
+import { Mutation } from 'apollo-angular';
+import { UpdateMatchInput } from '../api.service';
+import { Match } from '../model';
+
+@Injectable({ providedIn: 'root' })
+export class UpdateMatchGQL extends Mutation<{ updateMatch: Match }, { input: UpdateMatchInput }> {
+  document = gql`
+    mutation UpdateMatch($input: UpdateMatchInput!) {
+      updateMatch(input: $input) {
+        id
+      }
+    }
+  `;
+}

--- a/libs/client/conference/matches/data-access/src/lib/state/actions/matches.actions.ts
+++ b/libs/client/conference/matches/data-access/src/lib/state/actions/matches.actions.ts
@@ -21,3 +21,12 @@ export const matchCreatedFromPairLike = createAction(
   '[Matches] Match created from pair like',
   props<{ newPairMatch: Match }>()
 );
+
+export const markMatchAsRead = createAction(
+  '[Matches] Mark match as read',
+  props<{ matchId: string; attendeeId: string; attendee1Id: string; attendee2Id: string }>()
+);
+
+export const markMatchAsReadSuccess = createAction('[Matches] Mark match as read success');
+
+export const markMatchAsReadFailed = createAction('[Matches] Mark match as read failed');

--- a/libs/client/conference/matches/data-access/src/lib/state/effects/matches.effects.ts
+++ b/libs/client/conference/matches/data-access/src/lib/state/effects/matches.effects.ts
@@ -235,6 +235,7 @@ export class MatchesEffects {
         return of(null);
       }
       input.viewedByAttendee2 = true;
+      console.log('markMatchAsRead$:::::::::', input);
     } else {
       return throwError(
         () =>

--- a/libs/client/conference/matches/data-access/src/lib/state/effects/matches.effects.ts
+++ b/libs/client/conference/matches/data-access/src/lib/state/effects/matches.effects.ts
@@ -235,7 +235,6 @@ export class MatchesEffects {
         return of(null);
       }
       input.viewedByAttendee2 = true;
-      console.log('markMatchAsRead$:::::::::', input);
     } else {
       return throwError(
         () =>

--- a/libs/shared/src/lib/new-connection/new-connection.component.html
+++ b/libs/shared/src/lib/new-connection/new-connection.component.html
@@ -3,8 +3,8 @@
   <section (click)="onChat()">
     <img
       *ngIf="matchAttendee?.avatarUrl"
-      src="matchAttendee.avatarUrl"
-      alt="matchAttendee.fullName"
+      src="{{ matchAttendee.avatarUrl }}"
+      alt="{{ matchAttendee.fullName }}"
       class="avatar-image"
     />
     <h2>{{ t('new.newConnection') }}</h2>

--- a/libs/shared/src/lib/new-connection/new-connection.component.scss
+++ b/libs/shared/src/lib/new-connection/new-connection.component.scss
@@ -16,6 +16,7 @@
   }
 
   .avatar-image {
+    object-fit: cover;
     border-radius: 50%;
     width: 56px;
     height: 56px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@aws-amplify/core": "^3.8.21",
         "@ngneat/content-loader": "^7.0.0",
         "@ngneat/transloco": "4.1.1",
+        "@ngrx/component": "^14.3.2",
         "@ngrx/component-store": "14.0.2",
         "@ngrx/effects": "14.0.2",
         "@ngrx/store": "14.0.2",
@@ -7519,6 +7520,19 @@
       "dependencies": {
         "cosmiconfig": "^7.0.0",
         "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@ngrx/component": {
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/@ngrx/component/-/component-14.3.2.tgz",
+      "integrity": "sha512-SQlCcbW4CZb2vEPYGNvgeF27qa7dcPeLoui4mgof4FCdz/t3Bd+5EanDsqCm5GbHHPzasCBmN72+Lqt5E+mqgQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^14.0.0",
+        "@angular/core": "^14.0.0",
+        "rxjs": "^6.5.3 || ^7.5.0"
       }
     },
     "node_modules/@ngrx/component-store": {
@@ -64752,6 +64766,14 @@
       "requires": {
         "cosmiconfig": "^7.0.0",
         "tslib": "^2.3.0"
+      }
+    },
+    "@ngrx/component": {
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/@ngrx/component/-/component-14.3.2.tgz",
+      "integrity": "sha512-SQlCcbW4CZb2vEPYGNvgeF27qa7dcPeLoui4mgof4FCdz/t3Bd+5EanDsqCm5GbHHPzasCBmN72+Lqt5E+mqgQ==",
+      "requires": {
+        "tslib": "^2.0.0"
       }
     },
     "@ngrx/component-store": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@aws-amplify/auth": "^3.4.29",
     "@aws-amplify/core": "^3.8.21",
     "@ngneat/transloco": "4.1.1",
+    "@ngrx/component": "^14.3.2",
     "@ngrx/component-store": "14.0.2",
     "@ngrx/effects": "14.0.2",
     "@ngrx/store": "14.0.2",

--- a/serverless/amplify-schema.graphql
+++ b/serverless/amplify-schema.graphql
@@ -566,7 +566,7 @@ type Candidate
 type Match
   @model(
     queries: { list: "listMatches", get: "getMatch" }
-    mutations: { delete: "deleteMatch" }
+    mutations: { update: "updateMatch", delete: "deleteMatch" }
     subscriptions: null
   )
   @key(fields: ["attendee1Id", "attendee2Id"], name: "byAttendeesIds")
@@ -593,6 +593,8 @@ type Match
   attendee2: Attendee @connection(fields: ["attendee2Id"])
   interests: [MatchInterest] @connection(keyName: "byMatch", fields: ["id"])
   desiredIdentifiers: [MatchDesiredIdentifier] @connection(keyName: "byMatch", fields: ["id"])
+  viewedByAttendee1: Boolean
+  viewedByAttendee2: Boolean
 }
 
 type CandidateInterest

--- a/serverless/appsync-schema.graphql
+++ b/serverless/appsync-schema.graphql
@@ -376,6 +376,7 @@ type Mutation {
   deleteReport(input: DeleteReportInput!, condition: ModelReportConditionInput): Report
   updateChatThread(input: UpdateChatThreadInput!, condition: ModelChatThreadConditionInput): ChatThread
   createMessage(input: CreateMessageInput!, condition: ModelMessageConditionInput): Message
+  updateMatch(input: UpdateMatchInput!, condition: ModelMatchConditionInput): Match
   deleteMatch(input: DeleteMatchInput!, condition: ModelMatchConditionInput): Match
   createCandidateInterest(input: CreateCandidateInterestInput!, condition: ModelCandidateInterestConditionInput): CandidateInterest
   updateCandidateInterest(input: UpdateCandidateInterestInput!, condition: ModelCandidateInterestConditionInput): CandidateInterest
@@ -469,6 +470,8 @@ type Match {
   attendee2: Attendee
   interests(interestId: ModelIDKeyConditionInput, filter: ModelMatchInterestFilterInput, sortDirection: ModelSortDirection, limit: Int, nextToken: String): ModelMatchInterestConnection
   desiredIdentifiers(desiredIdentifierId: ModelIDKeyConditionInput, filter: ModelMatchDesiredIdentifierFilterInput, sortDirection: ModelSortDirection, limit: Int, nextToken: String): ModelMatchDesiredIdentifierConnection
+  viewedByAttendee1: Boolean
+  viewedByAttendee2: Boolean
   updatedAt: AWSDateTime!
 }
 
@@ -1307,9 +1310,22 @@ input ModelMatchFilterInput {
   attendee2Id: ModelIDInput
   eventId: ModelIDInput
   createdAt: ModelStringInput
+  viewedByAttendee1: ModelBooleanInput
+  viewedByAttendee2: ModelBooleanInput
   and: [ModelMatchFilterInput]
   or: [ModelMatchFilterInput]
   not: ModelMatchFilterInput
+}
+
+input UpdateMatchInput {
+  id: ID!
+  owners: [String!]
+  attendee1Id: ID
+  attendee2Id: ID
+  eventId: ID
+  createdAt: AWSDateTime
+  viewedByAttendee1: Boolean
+  viewedByAttendee2: Boolean
 }
 
 input DeleteMatchInput {
@@ -1321,6 +1337,8 @@ input ModelMatchConditionInput {
   attendee2Id: ModelIDInput
   eventId: ModelIDInput
   createdAt: ModelStringInput
+  viewedByAttendee1: ModelBooleanInput
+  viewedByAttendee2: ModelBooleanInput
   and: [ModelMatchConditionInput]
   or: [ModelMatchConditionInput]
   not: ModelMatchConditionInput

--- a/serverless/mapping-templates/Mutation.updateMatch.req.vtl
+++ b/serverless/mapping-templates/Mutation.updateMatch.req.vtl
@@ -1,0 +1,239 @@
+## [Start] Determine request authentication mode **
+#if( $util.isNullOrEmpty($authMode) && !$util.isNull($ctx.identity) && !$util.isNull($ctx.identity.sub) && !$util.isNull($ctx.identity.issuer) && !$util.isNull($ctx.identity.username) && !$util.isNull($ctx.identity.claims) && !$util.isNull($ctx.identity.sourceIp) && !$util.isNull($ctx.identity.defaultAuthStrategy) )
+  #set( $authMode = "userPools" )
+#end
+## [End] Determine request authentication mode **
+## [Start] Check authMode and execute owner/group checks **
+#if( $authMode == "userPools" )
+  ## [Start] Static Group Authorization Checks **
+  #set($isStaticGroupAuthorized = $util.defaultIfNull(
+            $isStaticGroupAuthorized, false))
+  ## Authorization rule: { allow: groups, groups: ["ADMINS"], groupClaim: "cognito:groups" } **
+  #set( $userGroups = $util.defaultIfNull($ctx.identity.claims.get("cognito:groups"), []) )
+  #set( $allowedGroups = ["ADMINS"] )
+  #foreach( $userGroup in $userGroups )
+    #if( $allowedGroups.contains($userGroup) )
+      #set( $isStaticGroupAuthorized = true )
+      #break
+    #end
+  #end
+  ## [End] Static Group Authorization Checks **
+
+
+  #if( ! $isStaticGroupAuthorized )
+    ## No dynamic group authorization rules **
+
+
+    ## [Start] Owner Authorization Checks **
+    #set( $ownerAuthExpressions = [] )
+    #set( $ownerAuthExpressionValues = {} )
+    #set( $ownerAuthExpressionNames = {} )
+    ## Authorization rule: { allow: owner, ownerField: "owners", identityClaim: "sub" } **
+    $util.qr($ownerAuthExpressions.add("contains(#owner0, :identity0)"))
+    $util.qr($ownerAuthExpressionNames.put("#owner0", "owners"))
+    $util.qr($ownerAuthExpressionValues.put(":identity0", $util.dynamodb.toDynamoDB($util.defaultIfNull($ctx.identity.claims.get("sub"), "___xamznone____"))))
+    ## [End] Owner Authorization Checks **
+
+
+    ## [Start] Collect Auth Condition **
+    #set( $authCondition = $util.defaultIfNull($authCondition, {
+  "expression": "",
+  "expressionNames": {},
+  "expressionValues": {}
+}) )
+    #set( $totalAuthExpression = "" )
+    ## Add dynamic group auth conditions if they exist **
+    #if( $groupAuthExpressions )
+      #foreach( $authExpr in $groupAuthExpressions )
+        #set( $totalAuthExpression = "$totalAuthExpression $authExpr" )
+        #if( $foreach.hasNext )
+          #set( $totalAuthExpression = "$totalAuthExpression OR" )
+        #end
+      #end
+    #end
+    #if( $groupAuthExpressionNames )
+      $util.qr($authCondition.expressionNames.putAll($groupAuthExpressionNames))
+    #end
+    #if( $groupAuthExpressionValues )
+      $util.qr($authCondition.expressionValues.putAll($groupAuthExpressionValues))
+    #end
+    ## Add owner auth conditions if they exist **
+    #if( $totalAuthExpression != "" && $ownerAuthExpressions && $ownerAuthExpressions.size() > 0 )
+      #set( $totalAuthExpression = "$totalAuthExpression OR" )
+    #end
+    #if( $ownerAuthExpressions )
+      #foreach( $authExpr in $ownerAuthExpressions )
+        #set( $totalAuthExpression = "$totalAuthExpression $authExpr" )
+        #if( $foreach.hasNext )
+          #set( $totalAuthExpression = "$totalAuthExpression OR" )
+        #end
+      #end
+    #end
+    #if( $ownerAuthExpressionNames )
+      $util.qr($authCondition.expressionNames.putAll($ownerAuthExpressionNames))
+    #end
+    #if( $ownerAuthExpressionValues )
+      $util.qr($authCondition.expressionValues.putAll($ownerAuthExpressionValues))
+    #end
+    ## Set final expression if it has changed. **
+    #if( $totalAuthExpression != "" )
+      #if( $util.isNullOrEmpty($authCondition.expression) )
+        #set( $authCondition.expression = "($totalAuthExpression)" )
+      #else
+        #set( $authCondition.expression = "$authCondition.expression AND ($totalAuthExpression)" )
+      #end
+    #end
+    ## [End] Collect Auth Condition **
+  #end
+
+
+  ## [Start] Throw if unauthorized **
+  #if( !($isStaticGroupAuthorized == true || ($totalAuthExpression != "")) )
+    $util.unauthorized()
+  #end
+  ## [End] Throw if unauthorized **
+#end
+## [End] Check authMode and execute owner/group checks **
+
+
+
+
+
+#set( $optionalNonNullableFields = ["owners", "attendee1Id", "attendee2Id", "eventId", "createdAt"] )
+#foreach( $field in $optionalNonNullableFields )
+  #if( $context.arguments.input.keySet().contains($field) && $util.isNull($context.args.input.get($field)) )
+$util.error("An argument you marked as Non-Null is set to Null in the query or the body of your request.")
+  #end
+#end
+#if( $authCondition && $authCondition.expression != "" )
+  #set( $condition = $authCondition )
+  #if( $modelObjectKey )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      $util.qr($condition.put("expression", "$condition.expression AND attribute_exists(#keyCondition$velocityCount)"))
+      $util.qr($condition.expressionNames.put("#keyCondition$velocityCount", "$entry.key"))
+    #end
+  #else
+    $util.qr($condition.put("expression", "$condition.expression AND attribute_exists(#id)"))
+    $util.qr($condition.expressionNames.put("#id", "id"))
+  #end
+#else
+  #if( $modelObjectKey )
+    #set( $condition = {
+  "expression": "",
+  "expressionNames": {},
+  "expressionValues": {}
+} )
+    #foreach( $entry in $modelObjectKey.entrySet() )
+      #if( $velocityCount == 1 )
+        $util.qr($condition.put("expression", "attribute_exists(#keyCondition$velocityCount)"))
+      #else
+        $util.qr($condition.put("expression", "$condition.expression AND attribute_exists(#keyCondition$velocityCount)"))
+      #end
+      $util.qr($condition.expressionNames.put("#keyCondition$velocityCount", "$entry.key"))
+    #end
+  #else
+    #set( $condition = {
+  "expression": "attribute_exists(#id)",
+  "expressionNames": {
+      "#id": "id"
+  },
+  "expressionValues": {}
+} )
+  #end
+#end
+## Automatically set the updatedAt timestamp. **
+$util.qr($context.args.input.put("updatedAt", $util.defaultIfNull($ctx.args.input.updatedAt, $util.time.nowISO8601())))
+$util.qr($context.args.input.put("__typename", "Match"))
+## Update condition if type is @versioned **
+#if( $versionedCondition )
+  $util.qr($condition.put("expression", "($condition.expression) AND $versionedCondition.expression"))
+  $util.qr($condition.expressionNames.putAll($versionedCondition.expressionNames))
+  $util.qr($condition.expressionValues.putAll($versionedCondition.expressionValues))
+#end
+#if( $context.args.condition )
+  #set( $conditionFilterExpressions = $util.parseJson($util.transform.toDynamoDBConditionExpression($context.args.condition)) )
+  $util.qr($condition.put("expression", "($condition.expression) AND $conditionFilterExpressions.expression"))
+  $util.qr($condition.expressionNames.putAll($conditionFilterExpressions.expressionNames))
+  $util.qr($condition.expressionValues.putAll($conditionFilterExpressions.expressionValues))
+#end
+#if( $condition.expressionValues && $condition.expressionValues.size() == 0 )
+  #set( $condition = {
+  "expression": $condition.expression,
+  "expressionNames": $condition.expressionNames
+} )
+#end
+#set( $expNames = {} )
+#set( $expValues = {} )
+#set( $expSet = {} )
+#set( $expAdd = {} )
+#set( $expRemove = [] )
+#if( $modelObjectKey )
+  #set( $keyFields = [] )
+  #foreach( $entry in $modelObjectKey.entrySet() )
+    $util.qr($keyFields.add("$entry.key"))
+  #end
+#else
+  #set( $keyFields = ["id"] )
+#end
+#foreach( $entry in $util.map.copyAndRemoveAllKeys($context.args.input, $keyFields).entrySet() )
+  #if( !$util.isNull($dynamodbNameOverrideMap) && $dynamodbNameOverrideMap.containsKey("$entry.key") )
+    #set( $entryKeyAttributeName = $dynamodbNameOverrideMap.get("$entry.key") )
+  #else
+    #set( $entryKeyAttributeName = $entry.key )
+  #end
+  #if( $util.isNull($entry.value) )
+    #set( $discard = $expRemove.add("#$entryKeyAttributeName") )
+    $util.qr($expNames.put("#$entryKeyAttributeName", "$entry.key"))
+  #else
+    $util.qr($expSet.put("#$entryKeyAttributeName", ":$entryKeyAttributeName"))
+    $util.qr($expNames.put("#$entryKeyAttributeName", "$entry.key"))
+    $util.qr($expValues.put(":$entryKeyAttributeName", $util.dynamodb.toDynamoDB($entry.value)))
+  #end
+#end
+#set( $expression = "" )
+#if( !$expSet.isEmpty() )
+  #set( $expression = "SET" )
+  #foreach( $entry in $expSet.entrySet() )
+    #set( $expression = "$expression $entry.key = $entry.value" )
+    #if( $foreach.hasNext() )
+      #set( $expression = "$expression," )
+    #end
+  #end
+#end
+#if( !$expAdd.isEmpty() )
+  #set( $expression = "$expression ADD" )
+  #foreach( $entry in $expAdd.entrySet() )
+    #set( $expression = "$expression $entry.key $entry.value" )
+    #if( $foreach.hasNext() )
+      #set( $expression = "$expression," )
+    #end
+  #end
+#end
+#if( !$expRemove.isEmpty() )
+  #set( $expression = "$expression REMOVE" )
+  #foreach( $entry in $expRemove )
+    #set( $expression = "$expression $entry" )
+    #if( $foreach.hasNext() )
+      #set( $expression = "$expression," )
+    #end
+  #end
+#end
+#set( $update = {} )
+$util.qr($update.put("expression", "$expression"))
+#if( !$expNames.isEmpty() )
+  $util.qr($update.put("expressionNames", $expNames))
+#end
+#if( !$expValues.isEmpty() )
+  $util.qr($update.put("expressionValues", $expValues))
+#end
+{
+  "version": "2018-05-29",
+  "operation": "UpdateItem",
+  "key": #if( $modelObjectKey ) $util.toJson($modelObjectKey) #else {
+  "id": {
+      "S": $util.toJson($context.args.input.id)
+  }
+} #end,
+  "update": $util.toJson($update),
+  "condition": $util.toJson($condition)
+}

--- a/serverless/mapping-templates/Mutation.updateMatch.res.vtl
+++ b/serverless/mapping-templates/Mutation.updateMatch.res.vtl
@@ -1,0 +1,5 @@
+#if( $ctx.error )
+$util.error($ctx.error.message, $ctx.error.type)
+#else
+$util.toJson($ctx.result)
+#end

--- a/serverless/serverless.mapping-templates.yml
+++ b/serverless/serverless.mapping-templates.yml
@@ -1,699 +1,706 @@
-- type: Query
-  field: getUser
-  dataSource: UserDataSource
-  request: Query.getUser.req.vtl
-  response: Query.getUser.res.vtl
-- type: Mutation
-  field: updateUser
-  dataSource: UserDataSource
-  request: Mutation.updateUser.req.vtl
-  response: Mutation.updateUser.res.vtl
-- type: Query
-  field: getUserByOwner
-  dataSource: UserDataSource
-  request: Query.getUserByOwner.req.vtl
-  response: Query.getUserByOwner.res.vtl
 
-- type: Query
-  field: getInterest
-  dataSource: InterestDataSource
-  request: Query.getInterest.req.vtl
-  response: Query.getInterest.res.vtl
-- type: Query
-  field: listInterests
-  dataSource: InterestDataSource
-  request: Query.listInterests.req.vtl
-  response: Query.listInterests.res.vtl
-- type: Mutation
-  field: createInterest
-  dataSource: InterestDataSource
-  request: Mutation.createInterest.req.vtl
-  response: Mutation.createInterest.res.vtl
-- type: Mutation
-  field: updateInterest
-  dataSource: InterestDataSource
-  request: Mutation.updateInterest.req.vtl
-  response: Mutation.updateInterest.res.vtl
-- type: Mutation
-  field: deleteInterest
-  dataSource: InterestDataSource
-  request: Mutation.deleteInterest.req.vtl
-  response: Mutation.deleteInterest.res.vtl
+  - type: Query
+    field: getUser
+    dataSource: UserDataSource
+    request: Query.getUser.req.vtl
+    response: Query.getUser.res.vtl
+  - type: Mutation
+    field: updateUser
+    dataSource: UserDataSource
+    request: Mutation.updateUser.req.vtl
+    response: Mutation.updateUser.res.vtl
+  - type: Query
+    field: getUserByOwner
+    dataSource: UserDataSource
+    request: Query.getUserByOwner.req.vtl
+    response: Query.getUserByOwner.res.vtl
 
-- type: Query
-  field: getIdentifier
-  dataSource: IdentifierDataSource
-  request: Query.getIdentifier.req.vtl
-  response: Query.getIdentifier.res.vtl
-- type: Query
-  field: listIdentifiers
-  dataSource: IdentifierDataSource
-  request: Query.listIdentifiers.req.vtl
-  response: Query.listIdentifiers.res.vtl
-- type: Mutation
-  field: createIdentifier
-  dataSource: IdentifierDataSource
-  request: Mutation.createIdentifier.req.vtl
-  response: Mutation.createIdentifier.res.vtl
-- type: Mutation
-  field: updateIdentifier
-  dataSource: IdentifierDataSource
-  request: Mutation.updateIdentifier.req.vtl
-  response: Mutation.updateIdentifier.res.vtl
-- type: Mutation
-  field: deleteIdentifier
-  dataSource: IdentifierDataSource
-  request: Mutation.deleteIdentifier.req.vtl
-  response: Mutation.deleteIdentifier.res.vtl
+  - type: Query
+    field: getInterest
+    dataSource: InterestDataSource
+    request: Query.getInterest.req.vtl
+    response: Query.getInterest.res.vtl
+  - type: Query
+    field: listInterests
+    dataSource: InterestDataSource
+    request: Query.listInterests.req.vtl
+    response: Query.listInterests.res.vtl
+  - type: Mutation
+    field: createInterest
+    dataSource: InterestDataSource
+    request: Mutation.createInterest.req.vtl
+    response: Mutation.createInterest.res.vtl
+  - type: Mutation
+    field: updateInterest
+    dataSource: InterestDataSource
+    request: Mutation.updateInterest.req.vtl
+    response: Mutation.updateInterest.res.vtl
+  - type: Mutation
+    field: deleteInterest
+    dataSource: InterestDataSource
+    request: Mutation.deleteInterest.req.vtl
+    response: Mutation.deleteInterest.res.vtl
 
-- type: Query
-  field: getTheme
-  dataSource: ThemeDataSource
-  request: Query.getTheme.req.vtl
-  response: Query.getTheme.res.vtl
-- type: Query
-  field: listThemes
-  dataSource: ThemeDataSource
-  request: Query.listThemes.req.vtl
-  response: Query.listThemes.res.vtl
-- type: Mutation
-  field: createTheme
-  dataSource: ThemeDataSource
-  request: Mutation.createTheme.req.vtl
-  response: Mutation.createTheme.res.vtl
-- type: Mutation
-  field: updateTheme
-  dataSource: ThemeDataSource
-  request: Mutation.updateTheme.req.vtl
-  response: Mutation.updateTheme.res.vtl
-- type: Mutation
-  field: deleteTheme
-  dataSource: ThemeDataSource
-  request: Mutation.deleteTheme.req.vtl
-  response: Mutation.deleteTheme.res.vtl
+  - type: Query
+    field: getIdentifier
+    dataSource: IdentifierDataSource
+    request: Query.getIdentifier.req.vtl
+    response: Query.getIdentifier.res.vtl
+  - type: Query
+    field: listIdentifiers
+    dataSource: IdentifierDataSource
+    request: Query.listIdentifiers.req.vtl
+    response: Query.listIdentifiers.res.vtl
+  - type: Mutation
+    field: createIdentifier
+    dataSource: IdentifierDataSource
+    request: Mutation.createIdentifier.req.vtl
+    response: Mutation.createIdentifier.res.vtl
+  - type: Mutation
+    field: updateIdentifier
+    dataSource: IdentifierDataSource
+    request: Mutation.updateIdentifier.req.vtl
+    response: Mutation.updateIdentifier.res.vtl
+  - type: Mutation
+    field: deleteIdentifier
+    dataSource: IdentifierDataSource
+    request: Mutation.deleteIdentifier.req.vtl
+    response: Mutation.deleteIdentifier.res.vtl
 
-- type: Query
-  field: getOrganizationMember
-  dataSource: OrganizationMemberDataSource
-  request: Query.getOrganizationMember.req.vtl
-  response: Query.getOrganizationMember.res.vtl
-- type: Query
-  field: listOrganizationMembers
-  dataSource: OrganizationMemberDataSource
-  request: Query.listOrganizationMembers.req.vtl
-  response: Query.listOrganizationMembers.res.vtl
-- type: Mutation
-  field: createOrganizationMember
-  dataSource: OrganizationMemberDataSource
-  request: Mutation.createOrganizationMember.req.vtl
-  response: Mutation.createOrganizationMember.res.vtl
-- type: Mutation
-  field: updateOrganizationMember
-  dataSource: OrganizationMemberDataSource
-  request: Mutation.updateOrganizationMember.req.vtl
-  response: Mutation.updateOrganizationMember.res.vtl
-- type: Mutation
-  field: deleteOrganizationMember
-  dataSource: OrganizationMemberDataSource
-  request: Mutation.deleteOrganizationMember.req.vtl
-  response: Mutation.deleteOrganizationMember.res.vtl
+  - type: Query
+    field: getTheme
+    dataSource: ThemeDataSource
+    request: Query.getTheme.req.vtl
+    response: Query.getTheme.res.vtl
+  - type: Query
+    field: listThemes
+    dataSource: ThemeDataSource
+    request: Query.listThemes.req.vtl
+    response: Query.listThemes.res.vtl
+  - type: Mutation
+    field: createTheme
+    dataSource: ThemeDataSource
+    request: Mutation.createTheme.req.vtl
+    response: Mutation.createTheme.res.vtl
+  - type: Mutation
+    field: updateTheme
+    dataSource: ThemeDataSource
+    request: Mutation.updateTheme.req.vtl
+    response: Mutation.updateTheme.res.vtl
+  - type: Mutation
+    field: deleteTheme
+    dataSource: ThemeDataSource
+    request: Mutation.deleteTheme.req.vtl
+    response: Mutation.deleteTheme.res.vtl
 
-- type: Query
-  field: getOrganization
-  dataSource: OrganizationDataSource
-  request: Query.getOrganization.req.vtl
-  response: Query.getOrganization.res.vtl
-- type: Query
-  field: listOrganizations
-  dataSource: OrganizationDataSource
-  request: Query.listOrganizations.req.vtl
-  response: Query.listOrganizations.res.vtl
-- type: Mutation
-  field: createOrganization
-  dataSource: OrganizationDataSource
-  request: Mutation.createOrganization.req.vtl
-  response: Mutation.createOrganization.res.vtl
-- type: Mutation
-  field: updateOrganization
-  dataSource: OrganizationDataSource
-  request: Mutation.updateOrganization.req.vtl
-  response: Mutation.updateOrganization.res.vtl
-- type: Mutation
-  field: deleteOrganization
-  dataSource: OrganizationDataSource
-  request: Mutation.deleteOrganization.req.vtl
-  response: Mutation.deleteOrganization.res.vtl
+  - type: Query
+    field: getOrganizationMember
+    dataSource: OrganizationMemberDataSource
+    request: Query.getOrganizationMember.req.vtl
+    response: Query.getOrganizationMember.res.vtl
+  - type: Query
+    field: listOrganizationMembers
+    dataSource: OrganizationMemberDataSource
+    request: Query.listOrganizationMembers.req.vtl
+    response: Query.listOrganizationMembers.res.vtl
+  - type: Mutation
+    field: createOrganizationMember
+    dataSource: OrganizationMemberDataSource
+    request: Mutation.createOrganizationMember.req.vtl
+    response: Mutation.createOrganizationMember.res.vtl
+  - type: Mutation
+    field: updateOrganizationMember
+    dataSource: OrganizationMemberDataSource
+    request: Mutation.updateOrganizationMember.req.vtl
+    response: Mutation.updateOrganizationMember.res.vtl
+  - type: Mutation
+    field: deleteOrganizationMember
+    dataSource: OrganizationMemberDataSource
+    request: Mutation.deleteOrganizationMember.req.vtl
+    response: Mutation.deleteOrganizationMember.res.vtl
 
-- type: Query
-  field: getEvent
-  dataSource: EventDataSource
-  request: Query.getEvent.req.vtl
-  response: Query.getEvent.res.vtl
-- type: Query
-  field: listEvents
-  dataSource: EventDataSource
-  request: Query.listEvents.req.vtl
-  response: Query.listEvents.res.vtl
-- type: Mutation
-  field: createEvent
-  dataSource: EventDataSource
-  request: Mutation.createEvent.req.vtl
-  response: Mutation.createEvent.res.vtl
-- type: Mutation
-  field: updateEvent
-  dataSource: EventDataSource
-  request: Mutation.updateEvent.req.vtl
-  response: Mutation.updateEvent.res.vtl
-- type: Mutation
-  field: deleteEvent
-  dataSource: EventDataSource
-  request: Mutation.deleteEvent.req.vtl
-  response: Mutation.deleteEvent.res.vtl
+  - type: Query
+    field: getOrganization
+    dataSource: OrganizationDataSource
+    request: Query.getOrganization.req.vtl
+    response: Query.getOrganization.res.vtl
+  - type: Query
+    field: listOrganizations
+    dataSource: OrganizationDataSource
+    request: Query.listOrganizations.req.vtl
+    response: Query.listOrganizations.res.vtl
+  - type: Mutation
+    field: createOrganization
+    dataSource: OrganizationDataSource
+    request: Mutation.createOrganization.req.vtl
+    response: Mutation.createOrganization.res.vtl
+  - type: Mutation
+    field: updateOrganization
+    dataSource: OrganizationDataSource
+    request: Mutation.updateOrganization.req.vtl
+    response: Mutation.updateOrganization.res.vtl
+  - type: Mutation
+    field: deleteOrganization
+    dataSource: OrganizationDataSource
+    request: Mutation.deleteOrganization.req.vtl
+    response: Mutation.deleteOrganization.res.vtl
 
-- type: Mutation
-  field: createEventInterest
-  dataSource: EventInterestDataSource
-  request: Mutation.createEventInterest.req.vtl
-  response: Mutation.createEventInterest.res.vtl
-- type: Mutation
-  field: updateEventInterest
-  dataSource: EventInterestDataSource
-  request: Mutation.updateEventInterest.req.vtl
-  response: Mutation.updateEventInterest.res.vtl
-- type: Mutation
-  field: deleteEventInterest
-  dataSource: EventInterestDataSource
-  request: Mutation.deleteEventInterest.req.vtl
-  response: Mutation.deleteEventInterest.res.vtl
+  - type: Query
+    field: getEvent
+    dataSource: EventDataSource
+    request: Query.getEvent.req.vtl
+    response: Query.getEvent.res.vtl
+  - type: Query
+    field: listEvents
+    dataSource: EventDataSource
+    request: Query.listEvents.req.vtl
+    response: Query.listEvents.res.vtl
+  - type: Mutation
+    field: createEvent
+    dataSource: EventDataSource
+    request: Mutation.createEvent.req.vtl
+    response: Mutation.createEvent.res.vtl
+  - type: Mutation
+    field: updateEvent
+    dataSource: EventDataSource
+    request: Mutation.updateEvent.req.vtl
+    response: Mutation.updateEvent.res.vtl
+  - type: Mutation
+    field: deleteEvent
+    dataSource: EventDataSource
+    request: Mutation.deleteEvent.req.vtl
+    response: Mutation.deleteEvent.res.vtl
 
-- type: Mutation
-  field: createEventIdentifier
-  dataSource: EventIdentifierDataSource
-  request: Mutation.createEventIdentifier.req.vtl
-  response: Mutation.createEventIdentifier.res.vtl
-- type: Mutation
-  field: updateEventIdentifier
-  dataSource: EventIdentifierDataSource
-  request: Mutation.updateEventIdentifier.req.vtl
-  response: Mutation.updateEventIdentifier.res.vtl
-- type: Mutation
-  field: deleteEventIdentifier
-  dataSource: EventIdentifierDataSource
-  request: Mutation.deleteEventIdentifier.req.vtl
-  response: Mutation.deleteEventIdentifier.res.vtl
+  - type: Mutation
+    field: createEventInterest
+    dataSource: EventInterestDataSource
+    request: Mutation.createEventInterest.req.vtl
+    response: Mutation.createEventInterest.res.vtl
+  - type: Mutation
+    field: updateEventInterest
+    dataSource: EventInterestDataSource
+    request: Mutation.updateEventInterest.req.vtl
+    response: Mutation.updateEventInterest.res.vtl
+  - type: Mutation
+    field: deleteEventInterest
+    dataSource: EventInterestDataSource
+    request: Mutation.deleteEventInterest.req.vtl
+    response: Mutation.deleteEventInterest.res.vtl
 
-- type: Query
-  field: getAttendee
-  dataSource: AttendeeDataSource
-  request: Query.getAttendee.req.vtl
-  response: Query.getAttendee.res.vtl
-- type: Query
-  field: listAttendees
-  dataSource: AttendeeDataSource
-  request: Query.listAttendees.req.vtl
-  response: Query.listAttendees.res.vtl
+  - type: Mutation
+    field: createEventIdentifier
+    dataSource: EventIdentifierDataSource
+    request: Mutation.createEventIdentifier.req.vtl
+    response: Mutation.createEventIdentifier.res.vtl
+  - type: Mutation
+    field: updateEventIdentifier
+    dataSource: EventIdentifierDataSource
+    request: Mutation.updateEventIdentifier.req.vtl
+    response: Mutation.updateEventIdentifier.res.vtl
+  - type: Mutation
+    field: deleteEventIdentifier
+    dataSource: EventIdentifierDataSource
+    request: Mutation.deleteEventIdentifier.req.vtl
+    response: Mutation.deleteEventIdentifier.res.vtl
 
-- type: Mutation
-  field: createAttendeeInterest
-  dataSource: AttendeeInterestDataSource
-  request: Mutation.createAttendeeInterest.req.vtl
-  response: Mutation.createAttendeeInterest.res.vtl
-- type: Mutation
-  field: updateAttendeeInterest
-  dataSource: AttendeeInterestDataSource
-  request: Mutation.updateAttendeeInterest.req.vtl
-  response: Mutation.updateAttendeeInterest.res.vtl
-- type: Mutation
-  field: deleteAttendeeInterest
-  dataSource: AttendeeInterestDataSource
-  request: Mutation.deleteAttendeeInterest.req.vtl
-  response: Mutation.deleteAttendeeInterest.res.vtl
+  - type: Query
+    field: getAttendee
+    dataSource: AttendeeDataSource
+    request: Query.getAttendee.req.vtl
+    response: Query.getAttendee.res.vtl
+  - type: Query
+    field: listAttendees
+    dataSource: AttendeeDataSource
+    request: Query.listAttendees.req.vtl
+    response: Query.listAttendees.res.vtl
 
-- type: Mutation
-  field: createAttendeeDesiredIdentifier
-  dataSource: AttendeeDesiredIdentifierDataSource
-  request: Mutation.createAttendeeDesiredIdentifier.req.vtl
-  response: Mutation.createAttendeeDesiredIdentifier.res.vtl
-- type: Mutation
-  field: updateAttendeeDesiredIdentifier
-  dataSource: AttendeeDesiredIdentifierDataSource
-  request: Mutation.updateAttendeeDesiredIdentifier.req.vtl
-  response: Mutation.updateAttendeeDesiredIdentifier.res.vtl
-- type: Mutation
-  field: deleteAttendeeDesiredIdentifier
-  dataSource: AttendeeDesiredIdentifierDataSource
-  request: Mutation.deleteAttendeeDesiredIdentifier.req.vtl
-  response: Mutation.deleteAttendeeDesiredIdentifier.res.vtl
+  - type: Mutation
+    field: createAttendeeInterest
+    dataSource: AttendeeInterestDataSource
+    request: Mutation.createAttendeeInterest.req.vtl
+    response: Mutation.createAttendeeInterest.res.vtl
+  - type: Mutation
+    field: updateAttendeeInterest
+    dataSource: AttendeeInterestDataSource
+    request: Mutation.updateAttendeeInterest.req.vtl
+    response: Mutation.updateAttendeeInterest.res.vtl
+  - type: Mutation
+    field: deleteAttendeeInterest
+    dataSource: AttendeeInterestDataSource
+    request: Mutation.deleteAttendeeInterest.req.vtl
+    response: Mutation.deleteAttendeeInterest.res.vtl
 
-- type: Mutation
-  field: createAttendeeOwnIdentifier
-  dataSource: AttendeeOwnIdentifierDataSource
-  request: Mutation.createAttendeeOwnIdentifier.req.vtl
-  response: Mutation.createAttendeeOwnIdentifier.res.vtl
-- type: Mutation
-  field: updateAttendeeOwnIdentifier
-  dataSource: AttendeeOwnIdentifierDataSource
-  request: Mutation.updateAttendeeOwnIdentifier.req.vtl
-  response: Mutation.updateAttendeeOwnIdentifier.res.vtl
-- type: Mutation
-  field: deleteAttendeeOwnIdentifier
-  dataSource: AttendeeOwnIdentifierDataSource
-  request: Mutation.deleteAttendeeOwnIdentifier.req.vtl
-  response: Mutation.deleteAttendeeOwnIdentifier.res.vtl
+  - type: Mutation
+    field: createAttendeeDesiredIdentifier
+    dataSource: AttendeeDesiredIdentifierDataSource
+    request: Mutation.createAttendeeDesiredIdentifier.req.vtl
+    response: Mutation.createAttendeeDesiredIdentifier.res.vtl
+  - type: Mutation
+    field: updateAttendeeDesiredIdentifier
+    dataSource: AttendeeDesiredIdentifierDataSource
+    request: Mutation.updateAttendeeDesiredIdentifier.req.vtl
+    response: Mutation.updateAttendeeDesiredIdentifier.res.vtl
+  - type: Mutation
+    field: deleteAttendeeDesiredIdentifier
+    dataSource: AttendeeDesiredIdentifierDataSource
+    request: Mutation.deleteAttendeeDesiredIdentifier.req.vtl
+    response: Mutation.deleteAttendeeDesiredIdentifier.res.vtl
 
-- type: Query
-  field: getReport
-  dataSource: ReportDataSource
-  request: Query.getReport.req.vtl
-  response: Query.getReport.res.vtl
-- type: Query
-  field: listReports
-  dataSource: ReportDataSource
-  request: Query.listReports.req.vtl
-  response: Query.listReports.res.vtl
-- type: Mutation
-  field: createReport
-  dataSource: ReportDataSource
-  request: Mutation.createReport.req.vtl
-  response: Mutation.createReport.res.vtl
-- type: Mutation
-  field: updateReport
-  dataSource: ReportDataSource
-  request: Mutation.updateReport.req.vtl
-  response: Mutation.updateReport.res.vtl
-- type: Mutation
-  field: deleteReport
-  dataSource: ReportDataSource
-  request: Mutation.deleteReport.req.vtl
-  response: Mutation.deleteReport.res.vtl
+  - type: Mutation
+    field: createAttendeeOwnIdentifier
+    dataSource: AttendeeOwnIdentifierDataSource
+    request: Mutation.createAttendeeOwnIdentifier.req.vtl
+    response: Mutation.createAttendeeOwnIdentifier.res.vtl
+  - type: Mutation
+    field: updateAttendeeOwnIdentifier
+    dataSource: AttendeeOwnIdentifierDataSource
+    request: Mutation.updateAttendeeOwnIdentifier.req.vtl
+    response: Mutation.updateAttendeeOwnIdentifier.res.vtl
+  - type: Mutation
+    field: deleteAttendeeOwnIdentifier
+    dataSource: AttendeeOwnIdentifierDataSource
+    request: Mutation.deleteAttendeeOwnIdentifier.req.vtl
+    response: Mutation.deleteAttendeeOwnIdentifier.res.vtl
 
-- type: Query
-  field: getChatThread
-  dataSource: ChatThreadDataSource
-  request: Query.getChatThread.req.vtl
-  response: Query.getChatThread.res.vtl
-- type: Query
-  field: listChatThreads
-  dataSource: ChatThreadDataSource
-  request: Query.listChatThreads.req.vtl
-  response: Query.listChatThreads.res.vtl
-- type: Mutation
-  field: updateChatThread
-  dataSource: ChatThreadDataSource
-  request: Mutation.updateChatThread.req.vtl
-  response: Mutation.updateChatThread.res.vtl
+  - type: Query
+    field: getReport
+    dataSource: ReportDataSource
+    request: Query.getReport.req.vtl
+    response: Query.getReport.res.vtl
+  - type: Query
+    field: listReports
+    dataSource: ReportDataSource
+    request: Query.listReports.req.vtl
+    response: Query.listReports.res.vtl
+  - type: Mutation
+    field: createReport
+    dataSource: ReportDataSource
+    request: Mutation.createReport.req.vtl
+    response: Mutation.createReport.res.vtl
+  - type: Mutation
+    field: updateReport
+    dataSource: ReportDataSource
+    request: Mutation.updateReport.req.vtl
+    response: Mutation.updateReport.res.vtl
+  - type: Mutation
+    field: deleteReport
+    dataSource: ReportDataSource
+    request: Mutation.deleteReport.req.vtl
+    response: Mutation.deleteReport.res.vtl
 
-- type: Mutation
-  field: createMessage
-  dataSource: MessageDataSource
-  request: Mutation.createMessage.req.vtl
-  response: Mutation.createMessage.res.vtl
+  - type: Query
+    field: getChatThread
+    dataSource: ChatThreadDataSource
+    request: Query.getChatThread.req.vtl
+    response: Query.getChatThread.res.vtl
+  - type: Query
+    field: listChatThreads
+    dataSource: ChatThreadDataSource
+    request: Query.listChatThreads.req.vtl
+    response: Query.listChatThreads.res.vtl
+  - type: Mutation
+    field: updateChatThread
+    dataSource: ChatThreadDataSource
+    request: Mutation.updateChatThread.req.vtl
+    response: Mutation.updateChatThread.res.vtl
 
-- type: Query
-  field: getCandidate
-  dataSource: CandidateDataSource
-  request: Query.getCandidate.req.vtl
-  response: Query.getCandidate.res.vtl
-- type: Query
-  field: listCandidates
-  dataSource: CandidateDataSource
-  request: Query.listCandidates.req.vtl
-  response: Query.listCandidates.res.vtl
-- type: Query
-  field: candidatesByEventId
-  dataSource: CandidateDataSource
-  request: Query.candidatesByEventId.req.vtl
-  response: Query.candidatesByEventId.res.vtl
+  - type: Mutation
+    field: createMessage
+    dataSource: MessageDataSource
+    request: Mutation.createMessage.req.vtl
+    response: Mutation.createMessage.res.vtl
 
-- type: Query
-  field: getMatch
-  dataSource: MatchDataSource
-  request: Query.getMatch.req.vtl
-  response: Query.getMatch.res.vtl
-- type: Query
-  field: listMatches
-  dataSource: MatchDataSource
-  request: Query.listMatches.req.vtl
-  response: Query.listMatches.res.vtl
-- type: Mutation
-  field: deleteMatch
-  dataSource: MatchDataSource
-  request: Mutation.deleteMatch.req.vtl
-  response: Mutation.deleteMatch.res.vtl
+  - type: Query
+    field: getCandidate
+    dataSource: CandidateDataSource
+    request: Query.getCandidate.req.vtl
+    response: Query.getCandidate.res.vtl
+  - type: Query
+    field: listCandidates
+    dataSource: CandidateDataSource
+    request: Query.listCandidates.req.vtl
+    response: Query.listCandidates.res.vtl
+  - type: Query
+    field: candidatesByEventId
+    dataSource: CandidateDataSource
+    request: Query.candidatesByEventId.req.vtl
+    response: Query.candidatesByEventId.res.vtl
 
-- type: Mutation
-  field: createCandidateInterest
-  dataSource: CandidateInterestDataSource
-  request: Mutation.createCandidateInterest.req.vtl
-  response: Mutation.createCandidateInterest.res.vtl
-- type: Mutation
-  field: updateCandidateInterest
-  dataSource: CandidateInterestDataSource
-  request: Mutation.updateCandidateInterest.req.vtl
-  response: Mutation.updateCandidateInterest.res.vtl
-- type: Mutation
-  field: deleteCandidateInterest
-  dataSource: CandidateInterestDataSource
-  request: Mutation.deleteCandidateInterest.req.vtl
-  response: Mutation.deleteCandidateInterest.res.vtl
+  - type: Query
+    field: getMatch
+    dataSource: MatchDataSource
+    request: Query.getMatch.req.vtl
+    response: Query.getMatch.res.vtl
+  - type: Query
+    field: listMatches
+    dataSource: MatchDataSource
+    request: Query.listMatches.req.vtl
+    response: Query.listMatches.res.vtl
+  - type: Mutation
+    field: updateMatch
+    dataSource: MatchDataSource
+    request: Mutation.updateMatch.req.vtl
+    response: Mutation.updateMatch.res.vtl
+  - type: Mutation
+    field: deleteMatch
+    dataSource: MatchDataSource
+    request: Mutation.deleteMatch.req.vtl
+    response: Mutation.deleteMatch.res.vtl
 
-- type: Mutation
-  field: createCandidateDesiredIdentifier
-  dataSource: CandidateDesiredIdentifierDataSource
-  request: Mutation.createCandidateDesiredIdentifier.req.vtl
-  response: Mutation.createCandidateDesiredIdentifier.res.vtl
-- type: Mutation
-  field: updateCandidateDesiredIdentifier
-  dataSource: CandidateDesiredIdentifierDataSource
-  request: Mutation.updateCandidateDesiredIdentifier.req.vtl
-  response: Mutation.updateCandidateDesiredIdentifier.res.vtl
-- type: Mutation
-  field: deleteCandidateDesiredIdentifier
-  dataSource: CandidateDesiredIdentifierDataSource
-  request: Mutation.deleteCandidateDesiredIdentifier.req.vtl
-  response: Mutation.deleteCandidateDesiredIdentifier.res.vtl
+  - type: Mutation
+    field: createCandidateInterest
+    dataSource: CandidateInterestDataSource
+    request: Mutation.createCandidateInterest.req.vtl
+    response: Mutation.createCandidateInterest.res.vtl
+  - type: Mutation
+    field: updateCandidateInterest
+    dataSource: CandidateInterestDataSource
+    request: Mutation.updateCandidateInterest.req.vtl
+    response: Mutation.updateCandidateInterest.res.vtl
+  - type: Mutation
+    field: deleteCandidateInterest
+    dataSource: CandidateInterestDataSource
+    request: Mutation.deleteCandidateInterest.req.vtl
+    response: Mutation.deleteCandidateInterest.res.vtl
 
-- type: Mutation
-  field: createMatchInterest
-  dataSource: MatchInterestDataSource
-  request: Mutation.createMatchInterest.req.vtl
-  response: Mutation.createMatchInterest.res.vtl
-- type: Mutation
-  field: updateMatchInterest
-  dataSource: MatchInterestDataSource
-  request: Mutation.updateMatchInterest.req.vtl
-  response: Mutation.updateMatchInterest.res.vtl
-- type: Mutation
-  field: deleteMatchInterest
-  dataSource: MatchInterestDataSource
-  request: Mutation.deleteMatchInterest.req.vtl
-  response: Mutation.deleteMatchInterest.res.vtl
+  - type: Mutation
+    field: createCandidateDesiredIdentifier
+    dataSource: CandidateDesiredIdentifierDataSource
+    request: Mutation.createCandidateDesiredIdentifier.req.vtl
+    response: Mutation.createCandidateDesiredIdentifier.res.vtl
+  - type: Mutation
+    field: updateCandidateDesiredIdentifier
+    dataSource: CandidateDesiredIdentifierDataSource
+    request: Mutation.updateCandidateDesiredIdentifier.req.vtl
+    response: Mutation.updateCandidateDesiredIdentifier.res.vtl
+  - type: Mutation
+    field: deleteCandidateDesiredIdentifier
+    dataSource: CandidateDesiredIdentifierDataSource
+    request: Mutation.deleteCandidateDesiredIdentifier.req.vtl
+    response: Mutation.deleteCandidateDesiredIdentifier.res.vtl
 
-- type: Mutation
-  field: createMatchDesiredIdentifier
-  dataSource: MatchDesiredIdentifierDataSource
-  request: Mutation.createMatchDesiredIdentifier.req.vtl
-  response: Mutation.createMatchDesiredIdentifier.res.vtl
-- type: Mutation
-  field: updateMatchDesiredIdentifier
-  dataSource: MatchDesiredIdentifierDataSource
-  request: Mutation.updateMatchDesiredIdentifier.req.vtl
-  response: Mutation.updateMatchDesiredIdentifier.res.vtl
-- type: Mutation
-  field: deleteMatchDesiredIdentifier
-  dataSource: MatchDesiredIdentifierDataSource
-  request: Mutation.deleteMatchDesiredIdentifier.req.vtl
-  response: Mutation.deleteMatchDesiredIdentifier.res.vtl
+  - type: Mutation
+    field: createMatchInterest
+    dataSource: MatchInterestDataSource
+    request: Mutation.createMatchInterest.req.vtl
+    response: Mutation.createMatchInterest.res.vtl
+  - type: Mutation
+    field: updateMatchInterest
+    dataSource: MatchInterestDataSource
+    request: Mutation.updateMatchInterest.req.vtl
+    response: Mutation.updateMatchInterest.res.vtl
+  - type: Mutation
+    field: deleteMatchInterest
+    dataSource: MatchInterestDataSource
+    request: Mutation.deleteMatchInterest.req.vtl
+    response: Mutation.deleteMatchInterest.res.vtl
 
-- type: Attendee
-  field: attendeeMatches
-  kind: 'PIPELINE'
-  request: Attendee.attendeeMatches.req.vtl
-  response: Attendee.attendeeMatches.res.vtl
-  functions:
-    - InvokeResolveMatchesLambdaDataSource
-- type: Attendee
-  field: attendeeChats
-  kind: 'PIPELINE'
-  request: Attendee.attendeeChats.req.vtl
-  response: Attendee.attendeeChats.res.vtl
-  functions:
-    - InvokeResolveChatsLambdaDataSource
-- type: Query
-  field: numberOfUnreadMessages
-  kind: 'PIPELINE'
-  request: Query.numberOfUnreadMessages.req.vtl
-  response: Query.numberOfUnreadMessages.res.vtl
-  functions:
-    - InvokeNumberOfUnreadMessagesLambdaDataSource
-- type: Mutation
-  field: accessEvent
-  kind: 'PIPELINE'
-  request: Mutation.accessEvent.req.vtl
-  response: Mutation.accessEvent.res.vtl
-  functions:
-    - InvokeAccessEventLambdaDataSource
-- type: Mutation
-  field: fileUpload
-  kind: 'PIPELINE'
-  request: Mutation.fileUpload.req.vtl
-  response: Mutation.fileUpload.res.vtl
-  functions:
-    - InvokeFileUploadLambdaDataSource
-- type: Mutation
-  field: createAttendee
-  kind: 'PIPELINE'
-  request: Mutation.createAttendee.req.vtl
-  response: Mutation.createAttendee.res.vtl
-  functions:
-    - InvokeCreateAttendeeLambdaDataSource
-- type: Mutation
-  field: updateAttendee
-  kind: 'PIPELINE'
-  request: Mutation.updateAttendee.req.vtl
-  response: Mutation.updateAttendee.res.vtl
-  functions:
-    - InvokeUpdateAttendeeLambdaDataSource
-- type: Mutation
-  field: updateCandidate
-  kind: 'PIPELINE'
-  request: Mutation.updateCandidate.req.vtl
-  response: Mutation.updateCandidate.res.vtl
-  functions:
-    - InvokeUpdateCandidateLambdaDataSource
+  - type: Mutation
+    field: createMatchDesiredIdentifier
+    dataSource: MatchDesiredIdentifierDataSource
+    request: Mutation.createMatchDesiredIdentifier.req.vtl
+    response: Mutation.createMatchDesiredIdentifier.res.vtl
+  - type: Mutation
+    field: updateMatchDesiredIdentifier
+    dataSource: MatchDesiredIdentifierDataSource
+    request: Mutation.updateMatchDesiredIdentifier.req.vtl
+    response: Mutation.updateMatchDesiredIdentifier.res.vtl
+  - type: Mutation
+    field: deleteMatchDesiredIdentifier
+    dataSource: MatchDesiredIdentifierDataSource
+    request: Mutation.deleteMatchDesiredIdentifier.req.vtl
+    response: Mutation.deleteMatchDesiredIdentifier.res.vtl
 
-- type: OrganizationMember
-  field: organization
-  dataSource: OrganizationDataSource
-  request: OrganizationMember.organization.req.vtl
-  response: OrganizationMember.organization.res.vtl
-- type: Organization
-  field: events
-  dataSource: EventDataSource
-  request: Organization.events.req.vtl
-  response: Organization.events.res.vtl
-- type: Organization
-  field: members
-  dataSource: OrganizationMemberDataSource
-  request: Organization.members.req.vtl
-  response: Organization.members.res.vtl
-- type: Event
-  field: organization
-  dataSource: OrganizationDataSource
-  request: Event.organization.req.vtl
-  response: Event.organization.res.vtl
-- type: Event
-  field: theme
-  dataSource: ThemeDataSource
-  request: Event.theme.req.vtl
-  response: Event.theme.res.vtl
-- type: Event
-  field: interests
-  dataSource: EventInterestDataSource
-  request: Event.interests.req.vtl
-  response: Event.interests.res.vtl
-- type: Event
-  field: identifiers
-  dataSource: EventIdentifierDataSource
-  request: Event.identifiers.req.vtl
-  response: Event.identifiers.res.vtl
-- type: Event
-  field: attendees
-  dataSource: AttendeeDataSource
-  request: Event.attendees.req.vtl
-  response: Event.attendees.res.vtl
-- type: Event
-  field: reports
-  dataSource: ReportDataSource
-  request: Event.reports.req.vtl
-  response: Event.reports.res.vtl
-- type: EventInterest
-  field: event
-  dataSource: EventDataSource
-  request: EventInterest.event.req.vtl
-  response: EventInterest.event.res.vtl
-- type: EventInterest
-  field: interest
-  dataSource: InterestDataSource
-  request: EventInterest.interest.req.vtl
-  response: EventInterest.interest.res.vtl
-- type: EventIdentifier
-  field: event
-  dataSource: EventDataSource
-  request: EventIdentifier.event.req.vtl
-  response: EventIdentifier.event.res.vtl
-- type: EventIdentifier
-  field: identifier
-  dataSource: IdentifierDataSource
-  request: EventIdentifier.identifier.req.vtl
-  response: EventIdentifier.identifier.res.vtl
-- type: Attendee
-  field: interests
-  dataSource: AttendeeInterestDataSource
-  request: Attendee.interests.req.vtl
-  response: Attendee.interests.res.vtl
-- type: Attendee
-  field: desiredIdentifiers
-  dataSource: AttendeeDesiredIdentifierDataSource
-  request: Attendee.desiredIdentifiers.req.vtl
-  response: Attendee.desiredIdentifiers.res.vtl
-- type: Attendee
-  field: ownIdentifiers
-  dataSource: AttendeeOwnIdentifierDataSource
-  request: Attendee.ownIdentifiers.req.vtl
-  response: Attendee.ownIdentifiers.res.vtl
-- type: Attendee
-  field: event
-  dataSource: EventDataSource
-  request: Attendee.event.req.vtl
-  response: Attendee.event.res.vtl
-- type: AttendeeInterest
-  field: attendee
-  dataSource: AttendeeDataSource
-  request: AttendeeInterest.attendee.req.vtl
-  response: AttendeeInterest.attendee.res.vtl
-- type: AttendeeInterest
-  field: interest
-  dataSource: InterestDataSource
-  request: AttendeeInterest.interest.req.vtl
-  response: AttendeeInterest.interest.res.vtl
-- type: AttendeeDesiredIdentifier
-  field: attendee
-  dataSource: AttendeeDataSource
-  request: AttendeeDesiredIdentifier.attendee.req.vtl
-  response: AttendeeDesiredIdentifier.attendee.res.vtl
-- type: AttendeeDesiredIdentifier
-  field: identifier
-  dataSource: IdentifierDataSource
-  request: AttendeeDesiredIdentifier.identifier.req.vtl
-  response: AttendeeDesiredIdentifier.identifier.res.vtl
-- type: AttendeeOwnIdentifier
-  field: attendee
-  dataSource: AttendeeDataSource
-  request: AttendeeOwnIdentifier.attendee.req.vtl
-  response: AttendeeOwnIdentifier.attendee.res.vtl
-- type: AttendeeOwnIdentifier
-  field: identifier
-  dataSource: IdentifierDataSource
-  request: AttendeeOwnIdentifier.identifier.req.vtl
-  response: AttendeeOwnIdentifier.identifier.res.vtl
-- type: Report
-  field: event
-  dataSource: EventDataSource
-  request: Report.event.req.vtl
-  response: Report.event.res.vtl
-- type: Report
-  field: reportingAttendee
-  dataSource: AttendeeDataSource
-  request: Report.reportingAttendee.req.vtl
-  response: Report.reportingAttendee.res.vtl
-- type: Report
-  field: reportedAttendee
-  dataSource: AttendeeDataSource
-  request: Report.reportedAttendee.req.vtl
-  response: Report.reportedAttendee.res.vtl
-- type: ChatThread
-  field: messages
-  dataSource: MessageDataSource
-  request: ChatThread.messages.req.vtl
-  response: ChatThread.messages.res.vtl
-- type: ChatThread
-  field: match
-  dataSource: MatchDataSource
-  request: ChatThread.match.req.vtl
-  response: ChatThread.match.res.vtl
-- type: Message
-  field: attendee
-  dataSource: AttendeeDataSource
-  request: Message.attendee.req.vtl
-  response: Message.attendee.res.vtl
-- type: Message
-  field: chatThread
-  dataSource: ChatThreadDataSource
-  request: Message.chatThread.req.vtl
-  response: Message.chatThread.res.vtl
-- type: Candidate
-  field: event
-  dataSource: EventDataSource
-  request: Candidate.event.req.vtl
-  response: Candidate.event.res.vtl
-- type: Candidate
-  field: attendee
-  dataSource: AttendeeDataSource
-  request: Candidate.attendee.req.vtl
-  response: Candidate.attendee.res.vtl
-- type: Candidate
-  field: interests
-  dataSource: CandidateInterestDataSource
-  request: Candidate.interests.req.vtl
-  response: Candidate.interests.res.vtl
-- type: Candidate
-  field: desiredIdentifiers
-  dataSource: CandidateDesiredIdentifierDataSource
-  request: Candidate.desiredIdentifiers.req.vtl
-  response: Candidate.desiredIdentifiers.res.vtl
-- type: Match
-  field: event
-  dataSource: EventDataSource
-  request: Match.event.req.vtl
-  response: Match.event.res.vtl
-- type: Match
-  field: attendee1
-  dataSource: AttendeeDataSource
-  request: Match.attendee1.req.vtl
-  response: Match.attendee1.res.vtl
-- type: Match
-  field: attendee2
-  dataSource: AttendeeDataSource
-  request: Match.attendee2.req.vtl
-  response: Match.attendee2.res.vtl
-- type: Match
-  field: interests
-  dataSource: MatchInterestDataSource
-  request: Match.interests.req.vtl
-  response: Match.interests.res.vtl
-- type: Match
-  field: desiredIdentifiers
-  dataSource: MatchDesiredIdentifierDataSource
-  request: Match.desiredIdentifiers.req.vtl
-  response: Match.desiredIdentifiers.res.vtl
-- type: CandidateInterest
-  field: candidate
-  dataSource: CandidateDataSource
-  request: CandidateInterest.candidate.req.vtl
-  response: CandidateInterest.candidate.res.vtl
-- type: CandidateInterest
-  field: interest
-  dataSource: InterestDataSource
-  request: CandidateInterest.interest.req.vtl
-  response: CandidateInterest.interest.res.vtl
-- type: CandidateDesiredIdentifier
-  field: candidate
-  dataSource: CandidateDataSource
-  request: CandidateDesiredIdentifier.candidate.req.vtl
-  response: CandidateDesiredIdentifier.candidate.res.vtl
-- type: CandidateDesiredIdentifier
-  field: desiredIdentifier
-  dataSource: IdentifierDataSource
-  request: CandidateDesiredIdentifier.desiredIdentifier.req.vtl
-  response: CandidateDesiredIdentifier.desiredIdentifier.res.vtl
-- type: MatchInterest
-  field: match
-  dataSource: MatchDataSource
-  request: MatchInterest.match.req.vtl
-  response: MatchInterest.match.res.vtl
-- type: MatchInterest
-  field: interest
-  dataSource: InterestDataSource
-  request: MatchInterest.interest.req.vtl
-  response: MatchInterest.interest.res.vtl
-- type: MatchDesiredIdentifier
-  field: match
-  dataSource: MatchDataSource
-  request: MatchDesiredIdentifier.match.req.vtl
-  response: MatchDesiredIdentifier.match.res.vtl
-- type: MatchDesiredIdentifier
-  field: desiredIdentifier
-  dataSource: IdentifierDataSource
-  request: MatchDesiredIdentifier.desiredIdentifier.req.vtl
-  response: MatchDesiredIdentifier.desiredIdentifier.res.vtl
+
+  - type: Attendee
+    field: attendeeMatches
+    kind: 'PIPELINE'
+    request: Attendee.attendeeMatches.req.vtl
+    response: Attendee.attendeeMatches.res.vtl
+    functions:
+      - InvokeResolveMatchesLambdaDataSource
+  - type: Attendee
+    field: attendeeChats
+    kind: 'PIPELINE'
+    request: Attendee.attendeeChats.req.vtl
+    response: Attendee.attendeeChats.res.vtl
+    functions:
+      - InvokeResolveChatsLambdaDataSource
+  - type: Query
+    field: numberOfUnreadMessages
+    kind: 'PIPELINE'
+    request: Query.numberOfUnreadMessages.req.vtl
+    response: Query.numberOfUnreadMessages.res.vtl
+    functions:
+      - InvokeNumberOfUnreadMessagesLambdaDataSource
+  - type: Mutation
+    field: accessEvent
+    kind: 'PIPELINE'
+    request: Mutation.accessEvent.req.vtl
+    response: Mutation.accessEvent.res.vtl
+    functions:
+      - InvokeAccessEventLambdaDataSource
+  - type: Mutation
+    field: fileUpload
+    kind: 'PIPELINE'
+    request: Mutation.fileUpload.req.vtl
+    response: Mutation.fileUpload.res.vtl
+    functions:
+      - InvokeFileUploadLambdaDataSource
+  - type: Mutation
+    field: createAttendee
+    kind: 'PIPELINE'
+    request: Mutation.createAttendee.req.vtl
+    response: Mutation.createAttendee.res.vtl
+    functions:
+      - InvokeCreateAttendeeLambdaDataSource
+  - type: Mutation
+    field: updateAttendee
+    kind: 'PIPELINE'
+    request: Mutation.updateAttendee.req.vtl
+    response: Mutation.updateAttendee.res.vtl
+    functions:
+      - InvokeUpdateAttendeeLambdaDataSource
+  - type: Mutation
+    field: updateCandidate
+    kind: 'PIPELINE'
+    request: Mutation.updateCandidate.req.vtl
+    response: Mutation.updateCandidate.res.vtl
+    functions:
+      - InvokeUpdateCandidateLambdaDataSource
+
+  - type: OrganizationMember
+    field: organization
+    dataSource: OrganizationDataSource
+    request: OrganizationMember.organization.req.vtl
+    response: OrganizationMember.organization.res.vtl
+  - type: Organization
+    field: events
+    dataSource: EventDataSource
+    request: Organization.events.req.vtl
+    response: Organization.events.res.vtl
+  - type: Organization
+    field: members
+    dataSource: OrganizationMemberDataSource
+    request: Organization.members.req.vtl
+    response: Organization.members.res.vtl
+  - type: Event
+    field: organization
+    dataSource: OrganizationDataSource
+    request: Event.organization.req.vtl
+    response: Event.organization.res.vtl
+  - type: Event
+    field: theme
+    dataSource: ThemeDataSource
+    request: Event.theme.req.vtl
+    response: Event.theme.res.vtl
+  - type: Event
+    field: interests
+    dataSource: EventInterestDataSource
+    request: Event.interests.req.vtl
+    response: Event.interests.res.vtl
+  - type: Event
+    field: identifiers
+    dataSource: EventIdentifierDataSource
+    request: Event.identifiers.req.vtl
+    response: Event.identifiers.res.vtl
+  - type: Event
+    field: attendees
+    dataSource: AttendeeDataSource
+    request: Event.attendees.req.vtl
+    response: Event.attendees.res.vtl
+  - type: Event
+    field: reports
+    dataSource: ReportDataSource
+    request: Event.reports.req.vtl
+    response: Event.reports.res.vtl
+  - type: EventInterest
+    field: event
+    dataSource: EventDataSource
+    request: EventInterest.event.req.vtl
+    response: EventInterest.event.res.vtl
+  - type: EventInterest
+    field: interest
+    dataSource: InterestDataSource
+    request: EventInterest.interest.req.vtl
+    response: EventInterest.interest.res.vtl
+  - type: EventIdentifier
+    field: event
+    dataSource: EventDataSource
+    request: EventIdentifier.event.req.vtl
+    response: EventIdentifier.event.res.vtl
+  - type: EventIdentifier
+    field: identifier
+    dataSource: IdentifierDataSource
+    request: EventIdentifier.identifier.req.vtl
+    response: EventIdentifier.identifier.res.vtl
+  - type: Attendee
+    field: interests
+    dataSource: AttendeeInterestDataSource
+    request: Attendee.interests.req.vtl
+    response: Attendee.interests.res.vtl
+  - type: Attendee
+    field: desiredIdentifiers
+    dataSource: AttendeeDesiredIdentifierDataSource
+    request: Attendee.desiredIdentifiers.req.vtl
+    response: Attendee.desiredIdentifiers.res.vtl
+  - type: Attendee
+    field: ownIdentifiers
+    dataSource: AttendeeOwnIdentifierDataSource
+    request: Attendee.ownIdentifiers.req.vtl
+    response: Attendee.ownIdentifiers.res.vtl
+  - type: Attendee
+    field: event
+    dataSource: EventDataSource
+    request: Attendee.event.req.vtl
+    response: Attendee.event.res.vtl
+  - type: AttendeeInterest
+    field: attendee
+    dataSource: AttendeeDataSource
+    request: AttendeeInterest.attendee.req.vtl
+    response: AttendeeInterest.attendee.res.vtl
+  - type: AttendeeInterest
+    field: interest
+    dataSource: InterestDataSource
+    request: AttendeeInterest.interest.req.vtl
+    response: AttendeeInterest.interest.res.vtl
+  - type: AttendeeDesiredIdentifier
+    field: attendee
+    dataSource: AttendeeDataSource
+    request: AttendeeDesiredIdentifier.attendee.req.vtl
+    response: AttendeeDesiredIdentifier.attendee.res.vtl
+  - type: AttendeeDesiredIdentifier
+    field: identifier
+    dataSource: IdentifierDataSource
+    request: AttendeeDesiredIdentifier.identifier.req.vtl
+    response: AttendeeDesiredIdentifier.identifier.res.vtl
+  - type: AttendeeOwnIdentifier
+    field: attendee
+    dataSource: AttendeeDataSource
+    request: AttendeeOwnIdentifier.attendee.req.vtl
+    response: AttendeeOwnIdentifier.attendee.res.vtl
+  - type: AttendeeOwnIdentifier
+    field: identifier
+    dataSource: IdentifierDataSource
+    request: AttendeeOwnIdentifier.identifier.req.vtl
+    response: AttendeeOwnIdentifier.identifier.res.vtl
+  - type: Report
+    field: event
+    dataSource: EventDataSource
+    request: Report.event.req.vtl
+    response: Report.event.res.vtl
+  - type: Report
+    field: reportingAttendee
+    dataSource: AttendeeDataSource
+    request: Report.reportingAttendee.req.vtl
+    response: Report.reportingAttendee.res.vtl
+  - type: Report
+    field: reportedAttendee
+    dataSource: AttendeeDataSource
+    request: Report.reportedAttendee.req.vtl
+    response: Report.reportedAttendee.res.vtl
+  - type: ChatThread
+    field: messages
+    dataSource: MessageDataSource
+    request: ChatThread.messages.req.vtl
+    response: ChatThread.messages.res.vtl
+  - type: ChatThread
+    field: match
+    dataSource: MatchDataSource
+    request: ChatThread.match.req.vtl
+    response: ChatThread.match.res.vtl
+  - type: Message
+    field: attendee
+    dataSource: AttendeeDataSource
+    request: Message.attendee.req.vtl
+    response: Message.attendee.res.vtl
+  - type: Message
+    field: chatThread
+    dataSource: ChatThreadDataSource
+    request: Message.chatThread.req.vtl
+    response: Message.chatThread.res.vtl
+  - type: Candidate
+    field: event
+    dataSource: EventDataSource
+    request: Candidate.event.req.vtl
+    response: Candidate.event.res.vtl
+  - type: Candidate
+    field: attendee
+    dataSource: AttendeeDataSource
+    request: Candidate.attendee.req.vtl
+    response: Candidate.attendee.res.vtl
+  - type: Candidate
+    field: interests
+    dataSource: CandidateInterestDataSource
+    request: Candidate.interests.req.vtl
+    response: Candidate.interests.res.vtl
+  - type: Candidate
+    field: desiredIdentifiers
+    dataSource: CandidateDesiredIdentifierDataSource
+    request: Candidate.desiredIdentifiers.req.vtl
+    response: Candidate.desiredIdentifiers.res.vtl
+  - type: Match
+    field: event
+    dataSource: EventDataSource
+    request: Match.event.req.vtl
+    response: Match.event.res.vtl
+  - type: Match
+    field: attendee1
+    dataSource: AttendeeDataSource
+    request: Match.attendee1.req.vtl
+    response: Match.attendee1.res.vtl
+  - type: Match
+    field: attendee2
+    dataSource: AttendeeDataSource
+    request: Match.attendee2.req.vtl
+    response: Match.attendee2.res.vtl
+  - type: Match
+    field: interests
+    dataSource: MatchInterestDataSource
+    request: Match.interests.req.vtl
+    response: Match.interests.res.vtl
+  - type: Match
+    field: desiredIdentifiers
+    dataSource: MatchDesiredIdentifierDataSource
+    request: Match.desiredIdentifiers.req.vtl
+    response: Match.desiredIdentifiers.res.vtl
+  - type: CandidateInterest
+    field: candidate
+    dataSource: CandidateDataSource
+    request: CandidateInterest.candidate.req.vtl
+    response: CandidateInterest.candidate.res.vtl
+  - type: CandidateInterest
+    field: interest
+    dataSource: InterestDataSource
+    request: CandidateInterest.interest.req.vtl
+    response: CandidateInterest.interest.res.vtl
+  - type: CandidateDesiredIdentifier
+    field: candidate
+    dataSource: CandidateDataSource
+    request: CandidateDesiredIdentifier.candidate.req.vtl
+    response: CandidateDesiredIdentifier.candidate.res.vtl
+  - type: CandidateDesiredIdentifier
+    field: desiredIdentifier
+    dataSource: IdentifierDataSource
+    request: CandidateDesiredIdentifier.desiredIdentifier.req.vtl
+    response: CandidateDesiredIdentifier.desiredIdentifier.res.vtl
+  - type: MatchInterest
+    field: match
+    dataSource: MatchDataSource
+    request: MatchInterest.match.req.vtl
+    response: MatchInterest.match.res.vtl
+  - type: MatchInterest
+    field: interest
+    dataSource: InterestDataSource
+    request: MatchInterest.interest.req.vtl
+    response: MatchInterest.interest.res.vtl
+  - type: MatchDesiredIdentifier
+    field: match
+    dataSource: MatchDataSource
+    request: MatchDesiredIdentifier.match.req.vtl
+    response: MatchDesiredIdentifier.match.res.vtl
+  - type: MatchDesiredIdentifier
+    field: desiredIdentifier
+    dataSource: IdentifierDataSource
+    request: MatchDesiredIdentifier.desiredIdentifier.req.vtl
+    response: MatchDesiredIdentifier.desiredIdentifier.res.vtl


### PR DESCRIPTION
# Overview

Resolves #19 

Dismisses the connection notification once either attendee dismisses it.

# Screenshots for Mobile and Desktop views (if applicable)

## Before

insert screenshot(s) here

## After

insert screenshot(s) here

# Details

## General

- List of changes
- Also list anything you haven't done or have deferred

## Automated Testing

- What unit tests have you added?
- What e2e/integration tests have you added?

### Manual Testing

Write the steps required for how might test this. Example:

_Note: requires two running instances of the app to get a match._

1. Perform Sign in and select the same conference
2. Connect with the first test users present (User 1 and 2 respectively in each instance)
3. Return to the connection view in both apps
4. See the notification for either or both
5. Dismiss the notification
6. Match with another user
7. See no notification
