### PR TITLE
fix: added scroll to inner modal content

### DIFF
--- a/apps/client/src/app/profile/edit-interests/edit-interests.component.scss
+++ b/apps/client/src/app/profile/edit-interests/edit-interests.component.scss
@@ -39,8 +39,13 @@
   }
 
   .interests__content {
-    margin-top: 2rem;
-    padding: 1rem;
+    padding: 2rem 1rem;
     width: 100%;
+    overflow-y: auto;
+    height: 50rem;
+
+    @include media_breakpoint_up(lg) {
+      height: 55rem;
+    }
   }
 }

--- a/apps/client/src/app/profile/edit-interests/edit-interests.component.scss
+++ b/apps/client/src/app/profile/edit-interests/edit-interests.component.scss
@@ -42,10 +42,6 @@
     padding: 2rem 1rem;
     width: 100%;
     overflow-y: auto;
-    height: 50rem;
-
-    @include media_breakpoint_up(lg) {
-      height: 55rem;
-    }
+    height: 100vh;
   }
 }


### PR DESCRIPTION
# Overview

Adds a scrollbar to the inner content of modals with content beyond the height of the container.

# Screenshots for Mobile and Desktop views (if applicable)

https://www.loom.com/share/60e33b7c01b44e60a18c4c10277323d6

# Details

## General

- Adds content overflow and height boundaries to the inner content.

### Manual Testing

1. Run `ng serve`
2. In browser, goto localhost:4200/path/to/change
3. Click on "Profile"
4. Click "Edit Profile"
5. Click the pencil icon next to "Interests"
6. Desktop: see the sidebar modal and scroll to the bottom of the interests list
7. Mobile: open the dev tools and enable mobile view then drag the view up/down
