### PR TITLE
fix: darker overlay to draw attention to correct save button

### DIFF
--- a/apps/client/src/app/profile/edit-profile/edit-profile.component.scss
+++ b/apps/client/src/app/profile/edit-profile/edit-profile.component.scss
@@ -22,7 +22,6 @@
 
 form {
   width: 100%;
-  padding-bottom: 8rem;
 
   @include media_breakpoint_up(md) {
     width: var(--profile-width-desktop);
@@ -52,7 +51,6 @@ form {
     flex-direction: row;
     justify-content: center;
     align-items: center;
-    position: fixed;
     width: 100%;
     left: 0;
     right: 0;
@@ -71,6 +69,8 @@ form {
     }
 
     button {
+      width: 100%;
+
       &:focus {
         outline: 1px solid rgb(229, 152, 0);
       }

--- a/libs/shared/src/lib/docked-modal/docked-modal.component.scss
+++ b/libs/shared/src/lib/docked-modal/docked-modal.component.scss
@@ -19,7 +19,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: rgba(0, 0, 0, 0.2);
+    background-color: rgba(0, 0, 0, 0.6);
   }
 
   .cm-docked-modal__modal {


### PR DESCRIPTION
# Overview

Makes the overlay darker so the focus is on the correct save button on the sidebar.

# Screenshots for Mobile and Desktop views (if applicable)

## Before

<img width="1083" alt="image" src="https://user-images.githubusercontent.com/9042219/220205215-622397c4-e720-415c-a2d8-808b0e979724.png">

## After

<img width="1084" alt="image" src="https://user-images.githubusercontent.com/9042219/220205171-38bd0857-7afb-4bad-9b61-dd9c1e0b138e.png">

# Details

## General

- Turns down the opacity from .2 to .8 to make the overlay darker

### Manual Testing

Write the steps required for how might test this. Example:

1. Run `ng serve`
2. In browser, goto localhost:4200/path/to/change
3. Edit profile
4. Desktop: Click any pencil icon to pop open the sidebar
5. See the overlay is darker
