### PR TITLE
Fix: Show user info in Chatters info

### DIFF
--- a/libs/api/src/lib/fragment/match.fragment.ts
+++ b/libs/api/src/lib/fragment/match.fragment.ts
@@ -64,24 +64,31 @@ export const matchAttendeeDetailsFragment = gql`
     id
     fullName
     bio
+    pronouns
     avatarUrl
     title
     interests {
-      interest {
-        id
-        name
+      items {
+        interest {
+          id
+          name
+        }
       }
     }
     desiredIdentifiers {
-      identifier {
-        id
-        name
+      items {
+        identifier {
+          id
+          name
+        }
       }
     }
     ownIdentifiers {
-      identifier {
-        id
-        name
+      items {
+        identifier {
+          id
+          name
+        }
       }
     }
     linkedin
@@ -93,6 +100,8 @@ export const matchAttendeeDetailsFragment = gql`
 
 export const matchDetailsFragment = gql`
   ${matchAttendeeDetailsFragment}
+  ${matchInterestFragment}
+  ${matchDesiredIdentifierFragment}
 
   fragment MatchDetails on Match {
     id
@@ -103,10 +112,14 @@ export const matchDetailsFragment = gql`
       ...MatchAttendeeDetails
     }
     interests {
-      ...MatchInterest
+      items {
+        ...MatchInterest
+      }
     }
     desiredIdentifiers {
-      ...MatchDesiredIdentifier
+      items {
+        ...MatchDesiredIdentifier
+      }
     }
     createdAt
   }


### PR DESCRIPTION
# Overview

What is included in this PR? Bug Fix? New Feature?

Bug fix

# Screenshots for Mobile and Desktop views (if applicable)

## Before
![Screen Shot 2023-02-21 at 4 36 20 PM](https://user-images.githubusercontent.com/16214572/220475440-dcd3ecb5-6e14-4519-8d9e-4637f16e47f9.png)

## After

<img width="407" alt="Screen Shot 2023-02-21 at 4 05 35 PM" src="https://user-images.githubusercontent.com/16214572/220473289-2eef0dc6-fccc-48eb-889d-d7e8fac10ff6.png">

# Details

## General

This adjust the gql fragment used to pull attendee information so that it correctly shows a user's info in the profile cards. The data was a little more nested than the query initially had.

### Manual Testing

Write the steps required for how might test this. Example:

1. Run `ng serve`
2. In browser, goto localhost:4200/conferences/00882957-5550-44bb-b15d-b0e512a0cec7/chatters/0dcfce5e-1492-4980-bee7-5ea34f9fda12
3. Click on "chatters" once you've matched with someone
4. Click the blue "info" icon next to a users name
5. You should now be able to see details populating into the profile card
