### PR TITLE
fix: update selector states with more control

### DIFF
--- a/apps/client/src/app/conferences/conferences.component.html
+++ b/apps/client/src/app/conferences/conferences.component.html
@@ -1,7 +1,7 @@
 <ng-container *transloco="let t; read: 'conferences.conferences'">
   <div class="cm-conferences">
     <ng-container *ngIf="conferences$ | async as conferences; else noResults">
-      <ng-container *ngIf="conferences.length > 0; else noConferences">
+      <ng-container *ngIf="conferencesLoaded$ | async">
         <ul>
           <li
             *ngFor="let conference of conferences; trackBy: trackById"
@@ -15,7 +15,7 @@
           </li>
         </ul>
       </ng-container>
-      <ng-template #noConferences>
+      <ng-container *ngIf="!(conferencesLoaded$ | async)">
         <div class="cm-conferences__empty">
           <div class="cm-conferences__empty__img-container">
             <img src="/assets/conferences-empty-state.svg" alt="" />
@@ -25,7 +25,7 @@
             {{ t('empty.text') }}
           </p>
         </div>
-      </ng-template>
+      </ng-container>
       <div class="cm-conferences__join">
         <button data-test-id="join conference" cm-button [floating]="true" (click)="openModal()">
           {{ t('joinConference') }}

--- a/apps/client/src/app/conferences/conferences.component.ts
+++ b/apps/client/src/app/conferences/conferences.component.ts
@@ -1,11 +1,11 @@
 import { Component } from '@angular/core';
-import { ModalService } from '@conf-match/shared';
-import { JoinConferenceModalComponent } from './join-conference-modal/join-conference-modal.component';
-import { filter, take } from 'rxjs/operators';
 import { Router } from '@angular/router';
+import { ModalService } from '@conf-match/shared';
+import { delay, filter, take } from 'rxjs/operators';
+import { JoinConferenceModalComponent } from './join-conference-modal/join-conference-modal.component';
 
-import { Store } from '@ngrx/store';
 import { Conference, ConferencesActions, ConferencesSelectors } from '@conf-match/core';
+import { Store } from '@ngrx/store';
 
 @Component({
   selector: 'cm-conferences',
@@ -13,7 +13,12 @@ import { Conference, ConferencesActions, ConferencesSelectors } from '@conf-matc
   styleUrls: ['./conferences.component.scss'],
 })
 export class ConferencesComponent {
-  readonly conferences$ = this._store.select(ConferencesSelectors.selectAttendeeConferences);
+  readonly conferences$ = this._store
+    .select(ConferencesSelectors.selectAttendeeConferences)
+    .pipe(delay(3000));
+  readonly conferencesLoaded$ = this._store.select(
+    ConferencesSelectors.selectAttendeeConferencesLoaded
+  );
   stack: any[] = [];
 
   constructor(

--- a/apps/client/src/app/conferences/conferences.module.ts
+++ b/apps/client/src/app/conferences/conferences.module.ts
@@ -1,33 +1,32 @@
-import { NgModule } from '@angular/core';
+import { A11yModule } from '@angular/cdk/a11y';
 import { CommonModule } from '@angular/common';
-import { ZXingScannerModule } from '@zxing/ngx-scanner';
-import { ConferencesRoutingModule } from './conferences-routing.module';
-import { ConferencesComponent } from './conferences.component';
-import { SharedModule as CmSharedModule } from '@conf-match/shared';
-import { SharedModule as AppSharedModule } from '../shared/shared.module';
-import { JoinConferenceModalComponent } from './join-conference-modal/join-conference-modal.component';
-import { ConferenceUrlFormComponent } from './conference-url-form/conference-url-form.component';
+import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { QrScanComponent } from './qr-scan/qr-scan.component';
-import { JoinConferenceComponent } from './join-conference/join-conference.component';
-import { JoinConferenceWizardComponent } from './join-conference/join-conference-wizard/join-conference-wizard.component';
-import { BasicInfoComponent } from './join-conference/join-conference-wizard/basic-info/basic-info.component';
-import { SocialsComponent } from './join-conference/join-conference-wizard/socials/socials.component';
-import { UploadPhotoComponent } from './join-conference/join-conference-wizard/upload-photo/upload-photo.component';
-import { LookingForComponent } from './join-conference/join-conference-wizard/looking-for/looking-for.component';
-import { InterestsComponent } from './join-conference/join-conference-wizard/interests/interests.component';
-import { BioComponent } from './join-conference/join-conference-wizard/bio/bio.component';
-import { WIZARD_FALLBACK_ROUTE } from '../shared/wizard';
+import { ClientSharedUiInputModule } from '@conf-match/client/shared/ui-input';
+import { SharedModule as CmSharedModule } from '@conf-match/shared';
+import { SharedDataAccessFileUploadModule } from '@conf-match/shared/data-access-file-upload';
 import { SharedUiButtonsModule } from '@conf-match/shared/ui-buttons';
 import { TranslocoModule } from '@ngneat/transloco';
-import { A11yModule } from '@angular/cdk/a11y';
+import { ZXingScannerModule } from '@zxing/ngx-scanner';
+import { SharedModule as AppSharedModule } from '../shared/shared.module';
+import { WIZARD_FALLBACK_ROUTE } from '../shared/wizard';
+import { ConferenceResolversModule } from './conference-resolvers/conference-resolvers.module';
+import { ConferenceUrlFormComponent } from './conference-url-form/conference-url-form.component';
+import { ConferencesRoutingModule } from './conferences-routing.module';
+import { ConferencesComponent } from './conferences.component';
+import { JoinConferenceModalComponent } from './join-conference-modal/join-conference-modal.component';
+import { BasicInfoComponent } from './join-conference/join-conference-wizard/basic-info/basic-info.component';
+import { BioComponent } from './join-conference/join-conference-wizard/bio/bio.component';
+import { InterestsComponent } from './join-conference/join-conference-wizard/interests/interests.component';
+import { JoinConferenceWizardComponent } from './join-conference/join-conference-wizard/join-conference-wizard.component';
+import { LookingForComponent } from './join-conference/join-conference-wizard/looking-for/looking-for.component';
+import { SocialsComponent } from './join-conference/join-conference-wizard/socials/socials.component';
+import { UploadPhotoComponent } from './join-conference/join-conference-wizard/upload-photo/upload-photo.component';
 import { WhoIAmComponent } from './join-conference/join-conference-wizard/who-i-am/who-i-am.component';
-import { SharedDataAccessFileUploadModule } from '@conf-match/shared/data-access-file-upload';
+import { JoinConferenceComponent } from './join-conference/join-conference.component';
+import { QrScanComponent } from './qr-scan/qr-scan.component';
 import { ReadQrInProgressComponent } from './qr-scan/read-qr-in-progress.component';
 import { ShareConferenceModalComponent } from './share-conference-modal/share-conference-modal.component';
-import { ConferenceResolversModule } from './conference-resolvers/conference-resolvers.module';
-import { ClientSharedUiInputModule } from '@conf-match/client/shared/ui-input';
-import { ContentLoaderModule } from '@ngneat/content-loader';
 
 @NgModule({
   declarations: [
@@ -60,7 +59,6 @@ import { ContentLoaderModule } from '@ngneat/content-loader';
     ZXingScannerModule,
     ConferenceResolversModule,
     ClientSharedUiInputModule,
-    ContentLoaderModule,
   ],
   providers: [
     {

--- a/apps/client/src/app/conferences/conferences.module.ts
+++ b/apps/client/src/app/conferences/conferences.module.ts
@@ -27,6 +27,7 @@ import { ReadQrInProgressComponent } from './qr-scan/read-qr-in-progress.compone
 import { ShareConferenceModalComponent } from './share-conference-modal/share-conference-modal.component';
 import { ConferenceResolversModule } from './conference-resolvers/conference-resolvers.module';
 import { ClientSharedUiInputModule } from '@conf-match/client/shared/ui-input';
+import { ContentLoaderModule } from '@ngneat/content-loader';
 
 @NgModule({
   declarations: [
@@ -59,6 +60,7 @@ import { ClientSharedUiInputModule } from '@conf-match/client/shared/ui-input';
     ZXingScannerModule,
     ConferenceResolversModule,
     ClientSharedUiInputModule,
+    ContentLoaderModule,
   ],
   providers: [
     {

--- a/apps/client/src/app/connect/connect.component.html
+++ b/apps/client/src/app/connect/connect.component.html
@@ -1,5 +1,5 @@
 <ng-container *transloco="let t; read: 'connect'">
-  <ng-container *ngIf="currentCandidate$ | async as currentCandidate; else noResults">
+  <ng-container *ngIf="currentCandidate$ | async as currentCandidate">
     <ng-container
       *ngIf="
         action !== 'like' &&
@@ -90,7 +90,7 @@
     ></cm-chatting-reasons-card>
   </ng-container>
 
-  <ng-template #noResults>
+  <ng-container *ngIf="!noMoreCandidates$ | async">
     <div
       *ngIf="
         (newMatch$ | async) === null ||
@@ -117,7 +117,7 @@
         {{ t('empty.description') }}
       </p>
     </div>
-  </ng-template>
+  </ng-container>
 </ng-container>
 
 <div *ngIf="action === 'confirmLike' && newMatch$ | async as newMatch">

--- a/apps/client/src/app/connect/connect.component.html
+++ b/apps/client/src/app/connect/connect.component.html
@@ -90,7 +90,7 @@
     ></cm-chatting-reasons-card>
   </ng-container>
 
-  <ng-container *ngIf="!noMoreCandidates$ | async">
+  <ng-container *ngIf="noMoreCandidates$ | async">
     <div
       *ngIf="
         (newMatch$ | async) === null ||

--- a/apps/client/src/app/connect/connect.component.ts
+++ b/apps/client/src/app/connect/connect.component.ts
@@ -1,3 +1,4 @@
+import { BreakpointObserver } from '@angular/cdk/layout';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -5,19 +6,18 @@ import {
   OnDestroy,
   OnInit,
 } from '@angular/core';
-import { Observable, Subscription } from 'rxjs';
-import { map, pluck, take } from 'rxjs/operators';
-import { Store } from '@ngrx/store';
 import { Candidate, CandidateType, Identifier, Interest } from '@conf-match/api';
-import { CmBreakpoints, ModalService, Storage } from '@conf-match/shared';
 import {
   ConnectActions,
   ConnectSelectors,
 } from '@conf-match/client/conference/connect/data-access';
-import { OnboardingComponent } from './onboarding/onboarding.component';
 import { MatchesSelectors } from '@conf-match/client/conference/matches/data-access';
 import { MatchesActions } from '@conf-match/client/conference/messages/data-access';
-import { BreakpointObserver } from '@angular/cdk/layout';
+import { CmBreakpoints, ModalService, Storage } from '@conf-match/shared';
+import { Store } from '@ngrx/store';
+import { Observable, Subscription } from 'rxjs';
+import { delay, map, pluck, take } from 'rxjs/operators';
+import { OnboardingComponent } from './onboarding/onboarding.component';
 
 // TODO: Decide where that key will be kept
 const OnboardingStorageKey = 'cm-onboarding-completed';
@@ -35,8 +35,11 @@ interface ActionOnCandidate {
 })
 export class ConnectComponent implements OnInit, OnDestroy {
   private isMobile$ = this.breakpointObserver.observe(CmBreakpoints.MD.DOWN).pipe(pluck('matches'));
-  currentCandidate$: Observable<Candidate> = this.store.select(
+  readonly currentCandidate$: Observable<Candidate> = this.store.select(
     ConnectSelectors.selectCurrentCandidate
+  );
+  readonly noMoreCandidates$: Observable<Boolean> = this.store.select(
+    ConnectSelectors.selectNoCandidates
   );
   CandidateType = CandidateType;
   candidates$: Observable<Candidate[]> = this.store

--- a/apps/client/src/app/connect/connect.component.ts
+++ b/apps/client/src/app/connect/connect.component.ts
@@ -16,7 +16,7 @@ import { MatchesActions } from '@conf-match/client/conference/messages/data-acce
 import { CmBreakpoints, ModalService, Storage } from '@conf-match/shared';
 import { Store } from '@ngrx/store';
 import { Observable, Subscription } from 'rxjs';
-import { delay, map, pluck, take } from 'rxjs/operators';
+import { map, pluck, take } from 'rxjs/operators';
 import { OnboardingComponent } from './onboarding/onboarding.component';
 
 // TODO: Decide where that key will be kept

--- a/apps/client/src/assets/i18n/en.json
+++ b/apps/client/src/assets/i18n/en.json
@@ -14,7 +14,7 @@
         "heading": "Welcome to Let's Chat With!",
         "text": "The best way to get started is to join a conference. You can scan a QR Code or use the conference URL provided by the organizers using the button below. Check your email or the check-in desk for more information."
       },
-      "noResults": "No Conferences yet, loading..."
+      "noResults": "Loading Conferences..."
     },
     "share": {
       "modal": {

--- a/libs/client/conference/connect/data-access/src/lib/state/selectors/connect.selectors.ts
+++ b/libs/client/conference/connect/data-access/src/lib/state/selectors/connect.selectors.ts
@@ -29,6 +29,7 @@ export const selectCurrentCandidate = createSelector(selectCandidates, (candidat
   candidates.find((candidate) => candidate.candidateType === CandidateType.UNDECIDED)
 );
 
-export const selectNoCandidates = createSelector(selectCandidates, (candidates) =>
-  Boolean(candidates.length)
+export const selectNoCandidates = createSelector(
+  selectCandidates,
+  (candidates) => !candidates.length
 );

--- a/libs/client/conference/connect/data-access/src/lib/state/selectors/connect.selectors.ts
+++ b/libs/client/conference/connect/data-access/src/lib/state/selectors/connect.selectors.ts
@@ -28,3 +28,7 @@ export const selectCandidates = createSelector(
 export const selectCurrentCandidate = createSelector(selectCandidates, (candidates) =>
   candidates.find((candidate) => candidate.candidateType === CandidateType.UNDECIDED)
 );
+
+export const selectNoCandidates = createSelector(selectCandidates, (candidates) =>
+  Boolean(candidates.length)
+);

--- a/libs/core/src/lib/state/conferences/selectors/conferences.selectors.ts
+++ b/libs/core/src/lib/state/conferences/selectors/conferences.selectors.ts
@@ -11,6 +11,10 @@ export const selectAttendeeConferences = createSelector(
   (conferences) => conferences?.attendeeConferences
 );
 
+export const selectAttendeeConferencesLoaded = createSelector(selectConferences, (conferences) =>
+  Boolean(conferences?.attendeeConferences.length)
+);
+
 export const selectAttendeeConferencesToSelect = createSelector(
   selectAttendeeConferences,
   selectConference,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@aws-amplify/api-graphql": "^1.2.29",
         "@aws-amplify/auth": "^3.4.29",
         "@aws-amplify/core": "^3.8.21",
+        "@ngneat/content-loader": "^7.0.0",
         "@ngneat/transloco": "4.1.1",
         "@ngrx/component-store": "14.0.2",
         "@ngrx/effects": "14.0.2",
@@ -7482,6 +7483,17 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
       "integrity": "sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig=="
+    },
+    "node_modules/@ngneat/content-loader": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@ngneat/content-loader/-/content-loader-7.0.0.tgz",
+      "integrity": "sha512-CfwsDxh2hsQfUwca3SWnyjQD5jcG6Vb6Ew0JIztj/spr3YIC9Obz7AqEVMDYPKch4QzPJiJ6OVRuLRM2DKiG9g==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">= 13.0.0"
+      }
     },
     "node_modules/@ngneat/transloco": {
       "version": "4.1.1",
@@ -64710,6 +64722,14 @@
           "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
           "integrity": "sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig=="
         }
+      }
+    },
+    "@ngneat/content-loader": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@ngneat/content-loader/-/content-loader-7.0.0.tgz",
+      "integrity": "sha512-CfwsDxh2hsQfUwca3SWnyjQD5jcG6Vb6Ew0JIztj/spr3YIC9Obz7AqEVMDYPKch4QzPJiJ6OVRuLRM2DKiG9g==",
+      "requires": {
+        "tslib": "^2.3.0"
       }
     },
     "@ngneat/transloco": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@aws-amplify/api-graphql": "^1.2.29",
     "@aws-amplify/auth": "^3.4.29",
     "@aws-amplify/core": "^3.8.21",
-    "@ngneat/content-loader": "^7.0.0",
     "@ngneat/transloco": "4.1.1",
     "@ngrx/component-store": "14.0.2",
     "@ngrx/effects": "14.0.2",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@aws-amplify/api-graphql": "^1.2.29",
     "@aws-amplify/auth": "^3.4.29",
     "@aws-amplify/core": "^3.8.21",
+    "@ngneat/content-loader": "^7.0.0",
     "@ngneat/transloco": "4.1.1",
     "@ngrx/component-store": "14.0.2",
     "@ngrx/effects": "14.0.2",


### PR DESCRIPTION
# Overview

Adds more control to loading states to prevent flickers during app loading on all screens.

_Note: test this on all views that load content and have a spinner: Conferences, Connect, Chatters, Messages, and Profile._

# Details

## General

- Adds selectors for loaded states
- Decouples template states rendering falsy templates before truthy templates

### Manual Testing

Write the steps required for how might test this. Example:

1. Run `ng serve`
2. In browser, goto localhost:4200
3. Sign in
4. View conferences loading
