### PR TITLE
fix: overflow auto and explicit height for sidebar content

### DIFF
--- a/apps/client/src/app/profile/edit-connections/edit-connections.component.scss
+++ b/apps/client/src/app/profile/edit-connections/edit-connections.component.scss
@@ -39,8 +39,9 @@
   }
 
   .connections__content {
-    margin-top: 2rem;
-    padding: 1rem;
+    padding: 3rem 1rem 1rem 1rem;
     width: 100%;
+    overflow: auto;
+    height: calc(100vh - 5.5rem);
   }
 }

--- a/apps/client/src/app/profile/edit-connections/edit-connections.component.scss
+++ b/apps/client/src/app/profile/edit-connections/edit-connections.component.scss
@@ -43,5 +43,6 @@
     width: 100%;
     overflow: auto;
     height: calc(100vh - 5.5rem);
+    height: calc(100svh - 5.5rem);
   }
 }

--- a/apps/client/src/app/profile/edit-interests/edit-interests.component.scss
+++ b/apps/client/src/app/profile/edit-interests/edit-interests.component.scss
@@ -43,5 +43,6 @@
     width: 100%;
     overflow: auto;
     height: calc(100vh - 5.5rem);
+    height: calc(100svh - 5.5rem);
   }
 }

--- a/apps/client/src/app/profile/edit-interests/edit-interests.component.scss
+++ b/apps/client/src/app/profile/edit-interests/edit-interests.component.scss
@@ -39,8 +39,9 @@
   }
 
   .interests__content {
-    margin-top: 2rem;
-    padding: 1rem;
+    padding: 3rem 1rem 1rem 1rem;
     width: 100%;
+    overflow: auto;
+    height: calc(100vh - 5.5rem);
   }
 }

--- a/apps/client/src/app/profile/edit-who-i-am/edit-who-i-am.component.scss
+++ b/apps/client/src/app/profile/edit-who-i-am/edit-who-i-am.component.scss
@@ -40,8 +40,9 @@
   }
 
   .who-i-am__content {
-    margin-top: 2rem;
-    padding: 1rem;
+    padding: 3rem 1rem 1rem 1rem;
     width: 100%;
+    overflow: auto;
+    height: calc(100vh - 5.5rem);
   }
 }

--- a/apps/client/src/app/profile/edit-who-i-am/edit-who-i-am.component.scss
+++ b/apps/client/src/app/profile/edit-who-i-am/edit-who-i-am.component.scss
@@ -44,5 +44,6 @@
     width: 100%;
     overflow: auto;
     height: calc(100vh - 5.5rem);
+    height: calc(100svh - 5.5rem);
   }
 }


### PR DESCRIPTION
# Overview

Made sidebar content scrollable.

# Screenshots for Mobile and Desktop views (if applicable)

## Before

<img width="224" alt="image" src="https://user-images.githubusercontent.com/11267785/220998103-f9d482da-a8ca-4097-a22a-1d8512dfeb0f.png">
## After

<img width="223" alt="image" src="https://user-images.githubusercontent.com/11267785/220997977-9082be41-b5e0-4653-b1b4-4711ca4b4efb.png">

# Details

## General

Added overflow: auto and explicit height for sidebar content for
- EditConnectionsComponent
- EditInterestsComponent
- EditWhoIAmComponent

## Automated Testing

N/A

### Manual Testing

Write the steps required for how might test this. Example:

1. Run `ng serve`
2. In browser, goto localhost:4200/path/to/change
3. Click on the red button
4. Get results :tada:
