### PR TITLE
Only show comma separator when title and company are present

### DIFF
--- a/libs/shared/src/lib/attendee-card/attendee-card.component.html
+++ b/libs/shared/src/lib/attendee-card/attendee-card.component.html
@@ -6,6 +6,6 @@
     <span>{{ attendee.fullName }}</span>
   </div>
   <div class="cm-attendee-card-profile__title">
-    <span>{{ attendee.title }}, {{ attendee.company }}</span>
+    <span>{{ [attendee.title, attendee.company] | stringSeparator }}</span>
   </div>
 </div>

--- a/libs/shared/src/lib/chatting-reasons/chatting-reasons-card.component.html
+++ b/libs/shared/src/lib/chatting-reasons/chatting-reasons-card.component.html
@@ -6,7 +6,7 @@
         {{ candidate.attendee.fullName }}
       </div>
       <div class="cm-chatting-reasons-card__attendee__description">
-        {{ candidate.attendee.title }}, {{ candidate.attendee.company }}
+        {{ [candidate.attendee.title, candidate.attendee.company] | stringSeparator }}
       </div>
       <div class="cm-chatting-reasons-card__attendee__pronouns">
         {{ candidate.attendee.pronouns }}

--- a/libs/shared/src/lib/connect-card/connect-card.component.html
+++ b/libs/shared/src/lib/connect-card/connect-card.component.html
@@ -6,7 +6,7 @@
         {{ attendee.fullName }}
       </div>
       <div class="cm-connect-card__content__description">
-        {{ attendee.title }}, {{ attendee.company }}
+        {{ [attendee.title, attendee.company] | stringSeparator }}
       </div>
       <div class="cm-connect-card__content__pronouns">
         {{ attendee.pronouns }}

--- a/libs/shared/src/lib/pipes/string-separator.pipe.spec.ts
+++ b/libs/shared/src/lib/pipes/string-separator.pipe.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed, waitForAsync } from '@angular/core/testing';
+import { StringSeparatorPipe } from './string-separator.pipe';
+
+describe('StringSeparatorPipe', () => {
+  let pipe: StringSeparatorPipe;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [StringSeparatorPipe],
+    }).compileComponents();
+
+    pipe = TestBed.inject(StringSeparatorPipe);
+  }));
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should show a comma between both strings if both values are provided', () => {
+    const entry = ['SE2', 'ThisDot'];
+    const result = pipe.transform(entry);
+    expect(result).toEqual('SE2, ThisDot');
+  });
+
+  it('should not show a comma if only one value is provided', () => {
+    const entry = ['ThisDot'];
+    const result = pipe.transform(entry);
+    expect(result).toEqual('ThisDot');
+  });
+
+  it('should show an empty string if no values are provided', () => {
+    const entry = [];
+    const result = pipe.transform(entry);
+    expect(result).toEqual('');
+  });
+});

--- a/libs/shared/src/lib/pipes/string-separator.pipe.spec.ts
+++ b/libs/shared/src/lib/pipes/string-separator.pipe.spec.ts
@@ -22,8 +22,14 @@ describe('StringSeparatorPipe', () => {
     expect(result).toEqual('SE2, ThisDot');
   });
 
-  it('should not show a comma if only one value is provided', () => {
-    const entry = ['ThisDot'];
+  it('should not show a comma if only the first value is provided', () => {
+    const entry = ['SE2', ''];
+    const result = pipe.transform(entry);
+    expect(result).toEqual('SE2');
+  });
+
+  it('should not show a comma if only the second value is provided', () => {
+    const entry = ['', 'ThisDot'];
     const result = pipe.transform(entry);
     expect(result).toEqual('ThisDot');
   });

--- a/libs/shared/src/lib/pipes/string-separator.pipe.ts
+++ b/libs/shared/src/lib/pipes/string-separator.pipe.ts
@@ -1,0 +1,26 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'stringSeparator',
+})
+export class StringSeparatorPipe implements PipeTransform {
+  transform(stringValues: string[]): string {
+    let finalString = '';
+
+    if (stringValues.length === 0) {
+      return finalString;
+    }
+
+    const firstValue = stringValues[0];
+    const secondValue = stringValues[1];
+
+    if (firstValue && secondValue) {
+      finalString = `${firstValue}, ${secondValue}`;
+    } else if (firstValue && !secondValue) {
+      finalString = firstValue;
+    } else if (!firstValue && secondValue) {
+      finalString = secondValue;
+    }
+    return finalString;
+  }
+}

--- a/libs/shared/src/lib/pipes/string-separator.pipe.ts
+++ b/libs/shared/src/lib/pipes/string-separator.pipe.ts
@@ -5,22 +5,18 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class StringSeparatorPipe implements PipeTransform {
   transform(stringValues: string[]): string {
-    let finalString = '';
-
     if (stringValues.length === 0) {
-      return finalString;
+      return '';
     }
 
-    const firstValue = stringValues[0];
-    const secondValue = stringValues[1];
+    const [firstValue, secondValue] = stringValues;
 
     if (firstValue && secondValue) {
-      finalString = `${firstValue}, ${secondValue}`;
+      return `${firstValue}, ${secondValue}`;
     } else if (firstValue && !secondValue) {
-      finalString = firstValue;
+      return firstValue;
     } else if (!firstValue && secondValue) {
-      finalString = secondValue;
+      return secondValue;
     }
-    return finalString;
   }
 }

--- a/libs/shared/src/lib/profile-card/profile-card.component.html
+++ b/libs/shared/src/lib/profile-card/profile-card.component.html
@@ -16,7 +16,7 @@
           {{ attendee.fullName }}
         </div>
         <div class="cm-profile-card__content__description">
-          {{ attendee.title }}
+          {{ [attendee.title, attendee.company] | stringSeparator }}
         </div>
         <div class="cm-profile-card__content__pronouns">
           {{ attendee.pronouns }}

--- a/libs/shared/src/lib/shared.module.ts
+++ b/libs/shared/src/lib/shared.module.ts
@@ -57,6 +57,7 @@ import { NewConnectionComponent } from './new-connection/new-connection.componen
 import { ClientSharedUiInputModule } from '@conf-match/client/shared/ui-input';
 import { ChattingReasonsCardComponent } from './chatting-reasons/chatting-reasons-card.component';
 import { YouAreChattersCardComponent } from './you-are-chatters/you-are-chatters-card.component';
+import { StringSeparatorPipe } from './pipes/string-separator.pipe';
 
 @NgModule({
   imports: [
@@ -118,6 +119,7 @@ import { YouAreChattersCardComponent } from './you-are-chatters/you-are-chatters
     SpinnerComponent,
     ChattingReasonsCardComponent,
     YouAreChattersCardComponent,
+    StringSeparatorPipe,
   ],
   exports: [
     ActionButtonComponent,
@@ -163,6 +165,7 @@ import { YouAreChattersCardComponent } from './you-are-chatters/you-are-chatters
     HamburgerMenuModule,
     ChattingReasonsCardComponent,
     YouAreChattersCardComponent,
+    StringSeparatorPipe,
   ],
   providers: [ModalService],
 })

--- a/libs/shared/src/lib/you-are-chatters/you-are-chatters-card.component.html
+++ b/libs/shared/src/lib/you-are-chatters/you-are-chatters-card.component.html
@@ -7,7 +7,7 @@
         {{ match.attendee.fullName }}
       </div>
       <div class="cm-you-are-chatters-card__attendee__description">
-        {{ match.attendee.title }}, {{ match.attendee.company }}
+        {{ [match.attendee.title, match.attendee.company] | stringSeparator }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Overview

Closes #9 

Provides a pipe to decide if a comma is needed to separate two strings.

# Screenshots for Mobile and Desktop views (if applicable)

## Before

![Screen Shot 2023-02-27 at 5 27 38 PM](https://user-images.githubusercontent.com/16214572/221712587-c0fb059d-d652-4016-bc4d-664f61b11879.png)

## After
Shows result for no provided values, one provided value, and both provided values

![Screen Shot 2023-02-27 at 5 18 04 PM](https://user-images.githubusercontent.com/16214572/221712307-12afa85f-1e35-411d-9c81-74595970b2b2.png)
![Screen Shot 2023-02-27 at 5 17 27 PM](https://user-images.githubusercontent.com/16214572/221712311-949215be-0820-4646-ad60-9c92bc331b9d.png)
![Screen Shot 2023-02-27 at 5 17 11 PM](https://user-images.githubusercontent.com/16214572/221712312-8bdb7391-56f9-4581-a810-1b4487a2eca7.png)

# Details

## General

Creates a pipe to handle the conditional logic of if a comma separator should appear between two provided values. The comma should appear if there are 2 values, and should not if only one value exists. It will return an empty string if neither value exists.

The related card components have also been updated to use this pipe.

## Automated Testing

Created a unit test for the pipe that checks for results if two values exist, if one exists, or if none exists.

### Manual Testing

Write the steps required for how might test this. Example:

1. Run `ng serve`
2. In browser, goto localhost:4200/conferences/<conf-id>/profile
3. Check the space underneath your name - should see the appropriate formatting depending on what values you provide.
4. Can edit your profile to add or remove job title and company to see the different results
5. This should also work when selecting new connections, and viewing chatter profiles
