### PR TITLE
fix: added chats value to the conferences effect

### DIFF
--- a/libs/core/src/lib/state/conferences/effects/conferences.effects.ts
+++ b/libs/core/src/lib/state/conferences/effects/conferences.effects.ts
@@ -66,7 +66,7 @@ export class ConferencesEffects {
 
   private convertEventsIntoConferences(events: EventModel[]): Conference[] {
     return events.map(
-      ({ id, name, description, logoUrl, letsChatWithUrl, qrImageUrl, matches }) => {
+      ({ id, name, description, logoUrl, letsChatWithUrl, qrImageUrl, matches, chats }) => {
         return {
           id,
           letsChatWithUrl,
@@ -77,6 +77,7 @@ export class ConferencesEffects {
           logoUrl,
           qrImageUrl,
           matches: matches.length,
+          chats: chats.length,
         } as Conference;
       }
     );


### PR DESCRIPTION
# Overview
Closes #6 

# Screenshots for Mobile and Desktop views (if applicable)

## After

![Screen Shot 2023-02-28 at 4 26 27 PM](https://user-images.githubusercontent.com/16214572/221995861-c0cdf739-eea1-467a-a0d9-2dd377d5fc97.png)

# Details

## General

- Adds the chat value to the final function call of the conferences effect
- This value was already being set in the previous function call, just missing from the final one

### Manual Testing

Write the steps required for how might test this. Example:

1. Run `ng serve`
2. In browser, goto localhost:4200/conferences
3. Note a value showing in front of the word "chats"
