### PR TITLE
fix: added filter for last message

### DIFF
--- a/libs/api/src/lib/queries/list-chat-threads.ts
+++ b/libs/api/src/lib/queries/list-chat-threads.ts
@@ -10,7 +10,7 @@ export const LIST_CHAT_THREADS_QUERY = gql`
       __typename
       items {
         id
-        messages(limit: 1, sortDirection: DESC) {
+        messages(limit: 10, sortDirection: DESC) {
           items {
             content
           }

--- a/libs/api/src/lib/queries/list-chat-threads.ts
+++ b/libs/api/src/lib/queries/list-chat-threads.ts
@@ -13,6 +13,7 @@ export const LIST_CHAT_THREADS_QUERY = gql`
         messages(limit: 10, sortDirection: DESC) {
           items {
             content
+            createdAt
           }
           nextToken
         }

--- a/libs/client/conference/messages/data-access/src/lib/state/selectors/messages.selectors.ts
+++ b/libs/client/conference/messages/data-access/src/lib/state/selectors/messages.selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector, createFeatureSelector } from '@ngrx/store';
 import { messageFeatureKey, MessagesState } from '../reducers';
-import { ChatThread, IdentifierModel, InterestModel } from '@conf-match/api';
+import { ChatThread, IdentifierModel, InterestModel, Message } from '@conf-match/api';
 import { MatchesSelectors } from '@conf-match/client/conference/matches/data-access';
 import { MatchAttendeeNumber } from '@conf-match/core';
 
@@ -40,6 +40,12 @@ export const selectFilteredChatThreadList = createSelector(
   selectChatThreadListTerm,
   (chatThreads, getMatchInfo, term) =>
     chatThreads
+      ?.map((chatThread) => {
+        const lastMessage = chatThread.messages.items.find(
+          (message: Message) => message.createdAt === chatThread.lastMessageAt
+        );
+        return { ...chatThread, messages: { ...chatThread.messages, items: [lastMessage] } };
+      })
       ?.filter(
         (chatThread: ChatThread & { matchId: string }) =>
           getMatchInfo(chatThread.matchId)


### PR DESCRIPTION
# Overview

Adds filtering to pick the last message from a chat thread.

AWS GraphQl's sorting doesn't work as intended and still jumbles the results despite the schema's sort criteria keyed on `createdAt` date. Sorting with option `DESC` seems to always put the last message as the second item in the array.

# Screenshots for Mobile and Desktop views (if applicable)

# Details

## General

- Ups the limit for the returned results to filter options
- Adds filtering to the list of messages

### Manual Testing

Write the steps required for how might test this. Example:

1. Sign in and create som message with a connection
2. View the messages page for the thread
3. See the latest message and compare with thread messages
