### PR TITLE
fix: added missing ui module

### DIFF
--- a/apps/client/src/app/recover-pass/recover-pass.module.ts
+++ b/apps/client/src/app/recover-pass/recover-pass.module.ts
@@ -1,18 +1,19 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Routes, RouterModule } from '@angular/router';
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
 import { ClientSharedUiTextFieldWrapperModule } from '@conf-match/client/shared/ui-text-field-wrapper';
 import { SharedModule as CmSharedModule } from '@conf-match/shared';
 import { SharedModule as AppSharedModule } from '../shared/shared.module';
 
-import { RecoverPassFlowComponent } from './recover-pass-flow/recover-pass-flow.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { ClientSharedUiInputModule } from '@conf-match/client/shared/ui-input';
+import { SharedUiButtonsModule } from '@conf-match/shared/ui-buttons';
+import { TranslocoModule } from '@ngneat/transloco';
 import { CurrentEmailComponent } from './recover-pass-flow/current-email/current-email.component';
 import { NewPasswordComponent } from './recover-pass-flow/new-password/new-password.component';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { SecurityCodeGuard } from './security-code.guard';
-import { SharedUiButtonsModule } from '@conf-match/shared/ui-buttons';
+import { RecoverPassFlowComponent } from './recover-pass-flow/recover-pass-flow.component';
 import { ResetCodeComponent } from './recover-pass-flow/reset-code/reset-code.component';
-import { TranslocoModule } from '@ngneat/transloco';
+import { SecurityCodeGuard } from './security-code.guard';
 
 const routes: Routes = [
   {
@@ -48,6 +49,7 @@ const routes: Routes = [
     CommonModule,
     CmSharedModule,
     ClientSharedUiTextFieldWrapperModule,
+    ClientSharedUiInputModule,
     AppSharedModule,
     FormsModule,
     ReactiveFormsModule,


### PR DESCRIPTION
# Overview

Fixes the unstyled input field during the password recovery flow.

# Screenshots for Mobile and Desktop views (if applicable)

<img width="509" alt="image" src="https://user-images.githubusercontent.com/9042219/222540932-a16466ef-62be-4cbd-9946-44440a4dcd36.png">


# Details

## General

- Adds the missing `ClientSharedUiInputModule` to the `RecoverPassModule`

## Automated Testing

- What unit tests have you added?
- What e2e/integration tests have you added?

### Manual Testing

Write the steps required for how might test this. Example:

1. Click "Forgot your password?"