### PR TITLE
Fix: terms style matching

### DIFF
--- a/apps/client/src/app/terms-of-service/terms-of-service.component.scss
+++ b/apps/client/src/app/terms-of-service/terms-of-service.component.scss
@@ -16,7 +16,21 @@
     color: var(--grey-900);
   }
 
+  h3 {
+    @extend %h100;
+    color: var(--grey-900);
+  }
+
   p {
     margin-bottom: 0.5rem;
+  }
+
+  ol {
+    @extend %text300;
+    line-height: 122%;
+  }
+
+  li {
+    padding-left: 0.7rem;
   }
 }


### PR DESCRIPTION
# Overview

Closes #3 
Updates some of the styling for the terms and conditions page so the whole page is consistent.

# Screenshots for Mobile and Desktop views (if applicable)
![Screen Shot 2023-03-02 at 7 03 34 PM](https://user-images.githubusercontent.com/16214572/222605756-e276e628-2ccd-4783-93cb-27f0a8ec6878.png)
![Screen Shot 2023-03-02 at 7 03 18 PM](https://user-images.githubusercontent.com/16214572/222605767-f1305486-d0c8-4a7d-8bdd-f0ba6d6d0e01.png)

# Details

## General

- Ordered lists have the right font, size, and spacing now. Also added a touch of extra padding between the numbers and the text so it's a little easier to read.
- Noticed the H3 headers were the wrong font as well so extended those so they match the other headers.

### Manual Testing

Write the steps required for how might test this. Example:

1. Run `ng serve`
2. Go to the settings page
3. Click on the terms section
