### PR TITLE
fix: enabled reports from chat messages

### DIFF
--- a/apps/client/src/app/messages/message-thread/message-thread.component.html
+++ b/apps/client/src/app/messages/message-thread/message-thread.component.html
@@ -1,16 +1,18 @@
 <ng-container *ngIf="thread$ | async as thread">
   <ng-container *transloco="let t; read: 'messages'">
-    <div class="cm-message-thread" *ngIf="matchAttendee$ | async as matchAttendee">
+    <div class="cm-message-thread" *ngIf="match$ | async as match">
       <div class="cm-message-thread__toolbar">
         <a class="cm-message-thread__back-button" routerLink="..">
           <cm-icon name="LeftChevron" size="xl"></cm-icon>
-          <cm-message-avatar [avatarUrl]="matchAttendee.avatarUrl"></cm-message-avatar>
+          <cm-message-avatar [avatarUrl]="match.attendee.avatarUrl"></cm-message-avatar>
           <div class="cm-message-thread__user-name">
-            {{ matchAttendee?.fullName }}
+            {{ match.attendee?.fullName }}
           </div>
         </a>
 
-        <cm-icon name="Flag" size="xl"></cm-icon>
+        <button (click)="onMenu(match)">
+          <cm-icon name="Flag" size="xl"></cm-icon>
+        </button>
       </div>
 
       <ng-container *ngIf="messages$ | async as messages; else noMessages">
@@ -18,7 +20,7 @@
           <cm-message-list
             [isLoading]="isLoading$ | async"
             [attendeeId]="attendeeId$ | async"
-            [matchAttendee]="matchAttendee$ | async"
+            [match]="(match$ | async).attendee"
             [messageThread]="thread"
             [messages]="messages"
             (loadNextPage)="onLoadNextPage()"
@@ -30,9 +32,7 @@
     </div>
     <ng-template #noMessages>
       <div class="cm-message-thread__no-messages">
-        <cm-message-thread-banner
-          [matchAttendee]="matchAttendee$ | async"
-        ></cm-message-thread-banner>
+        <cm-message-thread-banner [match]="(match$ | async).attendee"></cm-message-thread-banner>
         {{ t('firstMessage') }}
       </div>
     </ng-template>

--- a/apps/client/src/app/messages/message-thread/message-thread.component.ts
+++ b/apps/client/src/app/messages/message-thread/message-thread.component.ts
@@ -1,15 +1,20 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Router, ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ChatThread, GQLCollection, Match, Message } from '@conf-match/api';
+import { select, Store } from '@ngrx/store';
 import { Observable, Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
-import { ChatThread, GQLCollection, Message, MatchAttendee } from '@conf-match/api';
-import { Store, select } from '@ngrx/store';
+import { filter, takeUntil, tap } from 'rxjs/operators';
 
-import { selectConferenceId, selectAttendeeId } from '@conf-match/core';
 import {
-  MessagesSelectors,
   MessagesActions,
+  MessagesSelectors,
 } from '@conf-match/client/conference/messages/data-access';
+import { selectAttendeeId, selectConferenceId } from '@conf-match/core';
+import { ModalService } from '@conf-match/shared';
+import {
+  ConnectionActionMenuComponent,
+  ConnectionActionMenuComponentInput,
+} from '../../shared/connection-action-menu/connection-action-menu.component';
 
 @Component({
   selector: 'cm-message-thread',
@@ -17,27 +22,49 @@ import {
   styleUrls: ['./message-thread.component.scss'],
 })
 export class MessageThreadComponent implements OnInit, OnDestroy {
-  thread$: Observable<ChatThread>;
-  matchAttendee$: Observable<MatchAttendee>;
+  thread$: Observable<ChatThread> = this.store.pipe(
+    select(MessagesSelectors.selectChatThread),
+    tap((thread) => {
+      console.log(thread);
+      if (!thread) {
+        this.goToMessages();
+      }
+    })
+  );
+  match$: Observable<Match>;
   messages$: Observable<GQLCollection<Message>>;
   isLoading$: Observable<boolean>;
 
   attendeeId$ = this.store.pipe(select(selectAttendeeId));
   conferenceId: string;
 
-  private threadId: string;
+  private threadId = this.activatedRoute.snapshot.paramMap.get('chatThreadId');
+  readonly menuClickSubject = new Subject<Match>();
   private onDestroy$ = new Subject<void>();
 
   constructor(
     private router: Router,
     private activatedRoute: ActivatedRoute,
+    private modalService: ModalService,
     private store: Store<any>
   ) {
-    this.threadId = this.activatedRoute.snapshot.paramMap.get('chatThreadId');
-    this.thread$ = this.store.pipe(select(MessagesSelectors.selectChatThread));
     this.messages$ = this.store.pipe(select(MessagesSelectors.selectChatThreadMessages));
-    this.matchAttendee$ = this.store.pipe(select(MessagesSelectors.selectChatThreadAttendee));
+    this.match$ = this.store.pipe(select(MessagesSelectors.selectChatThreadInfo));
     this.isLoading$ = this.store.pipe(select(MessagesSelectors.selectIsLoadingMessages));
+
+    this.menuClickSubject
+      .asObservable()
+      .pipe(takeUntil(this.onDestroy$))
+      .subscribe((match) => {
+        this.modalService.openDockedModal<void, ConnectionActionMenuComponentInput>(
+          ConnectionActionMenuComponent,
+          {
+            reportedAttendee: match,
+            isMatch: true,
+            conferenceId: this.conferenceId,
+          }
+        );
+      });
   }
 
   ngOnInit() {
@@ -79,5 +106,9 @@ export class MessageThreadComponent implements OnInit, OnDestroy {
 
   updateAttendeeLastReadAt() {
     this.store.dispatch(MessagesActions.updateAttendeeLastReadAt({ chatThreadId: this.threadId }));
+  }
+
+  onMenu(match: Match) {
+    this.menuClickSubject.next(match);
   }
 }

--- a/apps/client/src/app/messages/message-thread/message-thread.component.ts
+++ b/apps/client/src/app/messages/message-thread/message-thread.component.ts
@@ -22,15 +22,7 @@ import {
   styleUrls: ['./message-thread.component.scss'],
 })
 export class MessageThreadComponent implements OnInit, OnDestroy {
-  thread$: Observable<ChatThread> = this.store.pipe(
-    select(MessagesSelectors.selectChatThread),
-    tap((thread) => {
-      console.log(thread);
-      if (!thread) {
-        this.goToMessages();
-      }
-    })
-  );
+  thread$: Observable<ChatThread>;
   match$: Observable<Match>;
   messages$: Observable<GQLCollection<Message>>;
   isLoading$: Observable<boolean>;
@@ -38,7 +30,7 @@ export class MessageThreadComponent implements OnInit, OnDestroy {
   attendeeId$ = this.store.pipe(select(selectAttendeeId));
   conferenceId: string;
 
-  private threadId = this.activatedRoute.snapshot.paramMap.get('chatThreadId');
+  private threadId: string;
   readonly menuClickSubject = new Subject<Match>();
   private onDestroy$ = new Subject<void>();
 
@@ -48,14 +40,17 @@ export class MessageThreadComponent implements OnInit, OnDestroy {
     private modalService: ModalService,
     private store: Store<any>
   ) {
-    this.messages$ = this.store.pipe(select(MessagesSelectors.selectChatThreadMessages));
+    this.threadId = this.activatedRoute.snapshot.paramMap.get('chatThreadId');
+    this.thread$ = this.store.pipe(select(MessagesSelectors.selectChatThread));
     this.match$ = this.store.pipe(select(MessagesSelectors.selectChatThreadInfo));
+    this.messages$ = this.store.pipe(select(MessagesSelectors.selectChatThreadMessages));
     this.isLoading$ = this.store.pipe(select(MessagesSelectors.selectIsLoadingMessages));
 
     this.menuClickSubject
       .asObservable()
       .pipe(takeUntil(this.onDestroy$))
       .subscribe((match) => {
+        this.goToMessages();
         this.modalService.openDockedModal<void, ConnectionActionMenuComponentInput>(
           ConnectionActionMenuComponent,
           {

--- a/libs/client/conference/messages/data-access/src/lib/state/selectors/messages.selectors.ts
+++ b/libs/client/conference/messages/data-access/src/lib/state/selectors/messages.selectors.ts
@@ -44,7 +44,10 @@ export const selectFilteredChatThreadList = createSelector(
         const lastMessage = chatThread.messages.items.find(
           (message: Message) => message.createdAt === chatThread.lastMessageAt
         );
-        return { ...chatThread, messages: { ...chatThread.messages, items: [lastMessage] } };
+        return {
+          ...chatThread,
+          messages: { ...chatThread.messages, items: lastMessage ? [lastMessage] : [] },
+        };
       })
       ?.filter(
         (chatThread: ChatThread & { matchId: string }) =>

--- a/libs/client/conference/messages/data-access/src/lib/state/selectors/messages.selectors.ts
+++ b/libs/client/conference/messages/data-access/src/lib/state/selectors/messages.selectors.ts
@@ -109,7 +109,6 @@ export const selectChatThreadAttendeeNumber = createSelector(
       return null;
     }
     const match = getMatchInfo(chatThread.matchId);
-    console.log(chatThread, match);
     return match.attendee1Id === match.attendee.id ? 'Attendee1' : 'Attendee2';
   }
 );

--- a/libs/client/conference/messages/data-access/src/lib/state/selectors/messages.selectors.ts
+++ b/libs/client/conference/messages/data-access/src/lib/state/selectors/messages.selectors.ts
@@ -91,11 +91,11 @@ export const selectChatThreadIdentifiers = createSelector(
   }
 );
 
-export const selectChatThreadAttendee = createSelector(
+export const selectChatThreadInfo = createSelector(
   selectChatThread,
   MatchesSelectors.selectGetMatchBasicInfo,
   (chatThread: ChatThread & { matchId: string }, getMatchInfo) => {
-    return chatThread ? getMatchInfo(chatThread.matchId)?.attendee : null;
+    return chatThread ? getMatchInfo(chatThread.matchId) : null;
   }
 );
 export const selectChatThreadAttendeeNumber = createSelector(
@@ -106,6 +106,7 @@ export const selectChatThreadAttendeeNumber = createSelector(
       return null;
     }
     const match = getMatchInfo(chatThread.matchId);
+    console.log(chatThread, match);
     return match.attendee1Id === match.attendee.id ? 'Attendee1' : 'Attendee2';
   }
 );


### PR DESCRIPTION
# Overview

Allows reporting chat threads.

# Details

## General

- Updates the chat thread attendee selector to return all details of the thread
- Adds a click handler and modal for message reporting
- Not the greatest experience, but reporting a message will route to message threads before opening the modal. This is to allow a clean removal of the match.

### Manual Testing

Write the steps required for how might test this. Example:

1. Create a match
2. Navigate to a thread
3. Click the flag on the message thread
4. Follow any flow options
