### PR TITLE
Fix: adjusted button styles for medium and down screens

### DIFF
--- a/apps/client/src/app/signup/signup-wizard/terms/application-terms.component.html
+++ b/apps/client/src/app/signup/signup-wizard/terms/application-terms.component.html
@@ -15,5 +15,5 @@
     >.
   </cm-terms-item>
 
-  <button cm-button [floating]="true" (click)="onAgree()">{{ t('iAgree') }}</button>
+  <button cm-button (click)="onAgree()">{{ t('iAgree') }}</button>
 </ng-container>

--- a/apps/client/src/app/signup/signup-wizard/terms/application-terms.component.scss
+++ b/apps/client/src/app/signup/signup-wizard/terms/application-terms.component.scss
@@ -1,4 +1,5 @@
 @import '../../../../../../../libs/client/shared/styles/src/lib/typography';
+@import '../../../../../../../libs/client/shared/styles/src/lib/breakpoints';
 
 .cm-terms {
   margin-top: 8px;
@@ -9,4 +10,19 @@
   @extend %h300;
   margin-top: 0;
   margin-bottom: 24px;
+}
+
+.cm-button {
+  position: fixed;
+  bottom: 58px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1;
+
+  @include media_breakpoint_down(md) {
+    width: 100%;
+    margin: 8px auto;
+    position: relative;
+    bottom: auto;
+  }
 }


### PR DESCRIPTION
# Overview

Bug fix - closes #26 

# Screenshots for Mobile and Desktop views (if applicable)

## Before
![Screen Shot 2023-03-09 at 5 51 47 PM](https://user-images.githubusercontent.com/16214572/224187260-438a43bc-94de-44a6-b82e-f31ea59c1911.png)

## After

![Screen Shot 2023-03-09 at 5 35 06 PM](https://user-images.githubusercontent.com/16214572/224187283-3f8fe5e4-714b-4d1e-b79d-675bedb549da.png)

![Screen Shot 2023-03-09 at 5 43 40 PM](https://user-images.githubusercontent.com/16214572/224187305-5f424d53-547e-437a-956d-81a99ffa3357.png)

# Details

## General

- Adjusted the styling so on medium and smaller screens, the button is full width and position below the list.
- Button maintains its fixed styling on larger screens.

It was simpler to copy the fixed button styles to this specific style page so those styles could be overwritten for smaller screens. Otherwise the styles that fix it into place take higher priority and aren't overwritten.

### Manual Testing

Write the steps required for how might test this. Example:

1. Run `ng serve`
2. Login with a new user account (only appears in the signup flow)
3. Notice the signup/terms page and button position at different sizes
