### PR TITLE
feat: set conf urls to lower case when created and attempting to join

### DIFF
--- a/apps/client/src/app/conferences/conference-url-form/conference-url-form.component.ts
+++ b/apps/client/src/app/conferences/conference-url-form/conference-url-form.component.ts
@@ -52,7 +52,9 @@ export class ConferenceUrlFormComponent implements OnInit, OnDestroy {
 
   submit() {
     if (this.form.valid) {
-      this.store.dispatch(conferenceJoinAttempted({ letsChatWithUrl: this.form.value.domain }));
+      this.store.dispatch(
+        conferenceJoinAttempted({ letsChatWithUrl: this.form.value.domain.toLowerCase() })
+      );
     }
   }
 }

--- a/serverless/handlers/create-event/index.js
+++ b/serverless/handlers/create-event/index.js
@@ -28,7 +28,7 @@ async function handler(lambdaEvent) {
     maxIdentifiers: event.maxIdentifiers,
     logoUrl: event.logoUrl,
     qrImageUrl: event.qrImageUrl,
-    letsChatWithUrl: event.letsChatWithUrl,
+    letsChatWithUrl: event.letsChatWithUrl.toLowerCase(),
     dateRange: event.dateRange,
     // the dev test organisation id is '052a154d-a0ac-4d83-89d4-77a95be6079f'
     organizationId: event.organizationId,


### PR DESCRIPTION
# Overview

What is included in this PR? Bug Fix? New Feature?

Closes #21 

Sets the conf url to lower case when creating an event and when trying to join an event.

# Details

## General

- On the createEvent handler, set the letsChatWithUrl to use `.toLowerCase()` so they'll always save as lower case
- When the "join conference" form is submitted, set it to pass the domain value using `.toLowerCase()` 

### Manual Testing

Write the steps required for how might test this. Example:

1. Run `ng serve`
2. In browser, goto localhost:4200/conferences
3. Try to join an existing conference using a mix of upper and lower case letters, or all upper case letters
4. Should see the card for the conference pop up as expected
