### PR TITLE
Fix (test): see if removing config allows amplify to build site

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -10,8 +10,8 @@ frontend:
         - npm run affected:lint
     build:
       commands:
-        - npm run build -- --configuration=thisdot-$ENVIRONMENT
-        - npm run build:admin -- --configuration=thisdot-$ENVIRONMENT
+        - npm run build
+        - npm run build:admin
   artifacts:
     baseDirectory: dist/apps
     files:


### PR DESCRIPTION
# Overview

This is an attempt to fix the deployments for the Amplify front-end sites. 

# Details

## General

Currently, the command to build the Amplify site is looking for a file that doesn't exist (in an amplify/environments/client folder we didn't copy over from the legacy repo). The reasoning for not copying those files over was to help keep the environment variables out of the repo itself. However, the config flag on the nx build command was not removed, so the builds have been failing.

I think this fix should allow the builds to start working again. 🤞🏼 
