### PR TITLE
Fix: adjusted lint command to run for correct branch

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -5,7 +5,8 @@ frontend:
     preBuild:
       commands:
         - npm ci --force
-        - npm run affected:lint
+        - if [ "${AWS_BRANCH}" = "main" ]; then npm run affected:lint --base=main; fi
+        - if [ "${AWS_BRANCH}" = "develop" ]; then npm run affected:lint"; fi
     build:
       commands:
         - npm run build


### PR DESCRIPTION
# Overview

Adjusts the `affected:lint` command in the amplify.yml to set the base for the main branch when it's on that branch. Should allow the rest of the build to proceed so the deployment works.
