### PR TITLE
Upgrade Dependencies to Fix Peer Dependency Errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,14 +87,13 @@
     "@zxing/browser": "^0.1.1",
     "@zxing/library": "^0.19.1",
     "@zxing/ngx-scanner": "^3.6.2",
-    "apollo-angular": "^1.9.1",
-    "apollo-angular-link-http": "^1.11.0",
+    "apollo-angular": "^5.0.0",
     "apollo-client": "^2.6.9",
     "apollo-link": "^1.2.14",
     "aws-appsync": "^3.0.3",
     "core-js": "3.9.1",
     "date-fns": "2.29.3",
-    "graphql": "^14.4.1",
+    "graphql": "^15.0.0",
     "graphql-tag": "^2.10.3",
     "hammerjs": "^2.0.8",
     "qrcode": "^1.5.1",
@@ -171,6 +170,7 @@
     "ts-jest": "28.0.8",
     "ts-node": "10.9.1",
     "tslint": "6.1.3",
-    "typescript": "4.8.4"
+    "typescript": "4.8.4",
+    "webpack": "5.74.0"
   }
 }


### PR DESCRIPTION
# Overview

Resolves #38

This PR upgrades `apollo-angular`, `graphql` and `webpack` to fix peer dependency issues and build issues currently affecting develop.

## Changes

- Set `apollo-angular` to version `^5.0.0`
- Set `graphql` to version `^15.0.0`
- Set `webpack to version `5.74.0`

## Automated Testing

No new tests were added.

### Manual Testing

Write the steps required for how might test this. Example:

1. Run `npm install`
2. Check that the command succeeds without errors
3. Run `npm run build`
4. Check that the frontend application builds without errors
